### PR TITLE
Bauf 58 implementiranje ekrana za pretraživanje radnika - Izgled stranice

### DIFF
--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
@@ -3,16 +3,16 @@ package hr.foi.air.baufind.mock.WorkerSearchMock
 object WorkerMock {
 
     data class Worker(
-        val id: Int,                // Jedinstveni identifikator radnika
-        val firstName: String,      // Ime radnika
-        val lastName: String,       // Prezime radnika
-        val location: String,       // Lokacija radnika (grad, regija)
-        val numOfJobs: Int,   // Broj poslova
-        val skills: List<String>,   // Lista vještina radnika (vodoinstaler, keramičar)
-        val availability: String,   // Dostupnost (npr. puno radno vrijeme, honorarni rad)
-        val expectedSalary: Double, // Očekivana plaća radnika
+        val id: Int,                
+        val firstName: String,
+        val lastName: String,
+        val location: String,
+        val numOfJobs: Int,
+        val skills: List<String>,
+        val availability: String,
+        val expectedSalary: Double,
         val contactInfo: String?,
-        val rating: Int// Kontakt podaci (ako postoji)
+        val rating: Int
     )
 
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
@@ -1,0 +1,26 @@
+package hr.foi.air.baufind.mock.WorkerSearchMock
+
+object WorkerMock {
+
+    data class Worker(
+        val id: Int,                // Jedinstveni identifikator radnika
+        val firstName: String,      // Ime radnika
+        val lastName: String,       // Prezime radnika
+        val location: String,       // Lokacija radnika (grad, regija)
+        val experienceYears: Int,   // Broj godina radnog iskustva
+        val skills: List<String>,   // Lista vještina radnika (npr. Java, Python, Vođenje projekata)
+        val jobCategory: String,    // Kategorija posla (npr. IT, Marketing, Administracija)
+        val availability: String,   // Dostupnost (npr. puno radno vrijeme, honorarni rad)
+        val expectedSalary: Double, // Očekivana plata radnika
+        val resumeLink: String?,    // Link na životopis (ako postoji)
+        val contactInfo: String?    // Kontakt podaci (ako postoji)
+    )
+
+
+    val workers = listOf(
+        Worker(1, "Ivan", "Horvat", "Zagreb", 3, listOf("Java", "Spring", "SQL"), "IT", "Full-time", 50000.0, "https://linktoresume.com/ivan", "ivan@email.com"),
+        Worker(2, "Ana", "Kovač", "Split", 5, listOf("Marketing", "SEO", "Content Creation"), "Marketing", "Freelance", 35000.0, null, "ana@email.com"),
+        Worker(3, "Marko", "Novak", "Osijek", 7, listOf("JavaScript", "Node.js", "React"), "IT", "Part-time", 45000.0, null, "marko@email.com"),
+        Worker(4, "Luka", "Ivić", "Zagreb", 2, listOf("Excel", "Data Analysis", "SQL"), "Administration", "Full-time", 40000.0, null, "luka@email.com")
+    )
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
@@ -11,15 +11,16 @@ object WorkerMock {
         val skills: List<String>,   // Lista vještina radnika (vodoinstaler, keramičar)
         val availability: String,   // Dostupnost (npr. puno radno vrijeme, honorarni rad)
         val expectedSalary: Double, // Očekivana plaća radnika
-        val contactInfo: String?    // Kontakt podaci (ako postoji)
+        val contactInfo: String?,
+        val rating: Int// Kontakt podaci (ako postoji)
     )
 
 
     val workers = listOf(
-        Worker(1, "Ivan", "Horvat", "Zagreb", 5, listOf("Vodoinstaler", "Keramičar"), "Full-time", 40000.0, "ivan@email.com"),
-        Worker(2, "Ana", "Kovač", "Split", 3, listOf("Keramičar", "Električar"), "Part-time", 30000.0, "ana@email.com"),
-        Worker(3, "Marko", "Novak", "Osijek", 10, listOf("Vodoinstaler", "Keramičar", "Instalater"), "Freelance", 45000.0, null),
-        Worker(4, "Luka", "Ivić", "Zadar", 8, listOf("Keramičar", "Majstor"), "Full-time", 35000.0, "luka@email.com")
+        Worker(1, "Ivan", "Horvat", "Zagreb", 5, listOf("Vodoinstaler", "Keramičar"), "Full-time", 40000.0, "ivan@email.com",5),
+        Worker(2, "Ana", "Kovač", "Split", 3, listOf("Keramičar", "Električar"), "Part-time", 30000.0, "ana@email.com",2),
+        Worker(3, "Marko", "Novak", "Osijek", 10, listOf("Vodoinstaler", "Keramičar", "Instalater"), "Freelance", 45000.0, null,10),
+        Worker(4, "Luka", "Ivić", "Zadar", 8, listOf("Keramičar", "Majstor"), "Full-time", 35000.0, "luka@email.com",7)
     )
 
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
@@ -7,20 +7,19 @@ object WorkerMock {
         val firstName: String,      // Ime radnika
         val lastName: String,       // Prezime radnika
         val location: String,       // Lokacija radnika (grad, regija)
-        val experienceYears: Int,   // Broj godina radnog iskustva
-        val skills: List<String>,   // Lista vještina radnika (npr. Java, Python, Vođenje projekata)
-        val jobCategory: String,    // Kategorija posla (npr. IT, Marketing, Administracija)
+        val numOfJobs: Int,   // Broj poslova
+        val skills: List<String>,   // Lista vještina radnika (vodoinstaler, keramičar)
         val availability: String,   // Dostupnost (npr. puno radno vrijeme, honorarni rad)
-        val expectedSalary: Double, // Očekivana plata radnika
-        val resumeLink: String?,    // Link na životopis (ako postoji)
+        val expectedSalary: Double, // Očekivana plaća radnika
         val contactInfo: String?    // Kontakt podaci (ako postoji)
     )
 
 
     val workers = listOf(
-        Worker(1, "Ivan", "Horvat", "Zagreb", 3, listOf("Java", "Spring", "SQL"), "IT", "Full-time", 50000.0, "https://linktoresume.com/ivan", "ivan@email.com"),
-        Worker(2, "Ana", "Kovač", "Split", 5, listOf("Marketing", "SEO", "Content Creation"), "Marketing", "Freelance", 35000.0, null, "ana@email.com"),
-        Worker(3, "Marko", "Novak", "Osijek", 7, listOf("JavaScript", "Node.js", "React"), "IT", "Part-time", 45000.0, null, "marko@email.com"),
-        Worker(4, "Luka", "Ivić", "Zagreb", 2, listOf("Excel", "Data Analysis", "SQL"), "Administration", "Full-time", 40000.0, null, "luka@email.com")
+        Worker(1, "Ivan", "Horvat", "Zagreb", 5, listOf("Vodoinstaler", "Keramičar"), "Full-time", 40000.0, "ivan@email.com"),
+        Worker(2, "Ana", "Kovač", "Split", 3, listOf("Keramičar", "Električar"), "Part-time", 30000.0, "ana@email.com"),
+        Worker(3, "Marko", "Novak", "Osijek", 10, listOf("Vodoinstaler", "Keramičar", "Instalater"), "Freelance", 45000.0, null),
+        Worker(4, "Luka", "Ivić", "Zadar", 8, listOf("Keramičar", "Majstor"), "Full-time", 35000.0, "luka@email.com")
     )
+
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
@@ -3,7 +3,7 @@ package hr.foi.air.baufind.mock.WorkerSearchMock
 object WorkerMock {
 
     data class Worker(
-        val id: Int,                
+        val id: Int,
         val firstName: String,
         val lastName: String,
         val location: String,

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCard.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCard.kt
@@ -1,0 +1,46 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerMock
+
+@Composable
+fun WorkerCard(
+    worker: WorkerMock.Worker,
+    onItemClick: () -> Unit
+) {
+    // Example UI for displaying worker's name and position
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(4.dp),
+        onClick = onItemClick
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ){
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(text = "Ime: ${worker.firstName} ${worker.lastName}", fontWeight = FontWeight.Bold)
+                Text(text = "Pozicija: ${worker.skills}")
+                Text(text = "Lokacija: ${worker.location}")
+                Text(text = "Broj poslova: ${worker.numOfJobs}")
+            }
+            Column(modifier = Modifier.padding(8.dp)
+            ) {
+                Text(text = "${worker.rating}", fontWeight = FontWeight.Bold, fontSize = 24.sp)
+
+            }
+        }
+
+    }
+
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -1,0 +1,19 @@
+package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+
+@Composable
+fun WorkerSearchScreen(navController: NavController){
+    val viewModel: WorkerSearchViewModel = viewModel()
+}
+@Preview
+@Composable
+fun WorkerSearchScreenPreview(){
+    val navController = rememberNavController()
+    WorkerSearchScreen(navController)
+}
+

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.rememberNavController
 @Composable
 fun WorkerSearchScreen(navController: NavController){
     val viewModel: WorkerSearchViewModel = viewModel()
+
 }
 @Preview
 @Composable

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -1,5 +1,8 @@
 package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
+import android.widget.Toast
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,13 +11,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.*
 import androidx.compose.material3.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -25,13 +32,16 @@ import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerMock
 fun WorkerSearchScreen(navController: NavController) {
     val viewModel: WorkerSearchViewModel = viewModel()
 
-
+    //Logika za dropdown meni
+    /// Preporučeno je za manji broj opcija koristiti chip
     val isExpandedL by viewModel.isExpandedL
     val isExpandedR by viewModel.isExpandedR
-
+    val scrollState = rememberScrollState()
     val selectedItemL by viewModel.selectedItemL
     val selectedItemR by viewModel.selectedItemR
     val workers by viewModel.workers
+    val context = LocalContext.current
+    // Opcije za dropdown meni
     val optionsR = listOf("Ocjena ASC", "Ocjena DESC", "Broj poslova ASC", "Broj poslova DESC")
     val optionsL = listOf("Zagrebačka", "Krapinsko-zagorska", "Sisacko-moslavačka", "Karlovačka", "Varaždinska",
          "Bjelovarsko-bilogorska", "Primorsko-goranska", "Ličko-senjska",
@@ -43,8 +53,9 @@ fun WorkerSearchScreen(navController: NavController) {
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text("Worker Search Screen")
 
-        // Left Dropdown
+
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+            //Lijevi dropdown meni
             ExposedDropdownMenuBox(
                 expanded = isExpandedL,
                 onExpandedChange = { viewModel.isExpandedL.value = it },
@@ -73,6 +84,7 @@ fun WorkerSearchScreen(navController: NavController) {
                     }
                 }
             }
+            //Desni dropdown meni
             ExposedDropdownMenuBox(
                 expanded = isExpandedR,
                 onExpandedChange = { viewModel.isExpandedR.value = it },
@@ -102,25 +114,47 @@ fun WorkerSearchScreen(navController: NavController) {
                 }
             }
         }
-        LazyColumn() {
+        //Lista radnika i prikaz i callback za pritisak
+        LazyColumn(
+            modifier = Modifier.scrollable(state = scrollState, orientation = Orientation.Vertical),
+
+        ) {
             items(workers){
-                worker -> WorkerItem(worker)
+                worker -> WorkerItem(worker){
+                    //Funkcija se poziva na pritiskom na radnika,| treba je promijeniti u kasnijim fazama i prilikom promjene obrišite dio komentara nakon | znaka.
+                   Toast.makeText(context, "Clicked on ${worker.firstName} ${worker.lastName}", Toast.LENGTH_SHORT).show()
+               }
             }
         }
     }
 }
 @Composable
-fun WorkerItem(worker: WorkerMock.Worker) {
+fun WorkerItem(
+    worker: WorkerMock.Worker,
+    onItemClick: () -> Unit
+) {
     // Example UI for displaying worker's name and position
     Card(
-        modifier = Modifier.fillMaxWidth().padding(4.dp)
+        modifier = Modifier.fillMaxWidth().padding(4.dp),
+        onClick = onItemClick
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(text = "Name: ${worker.firstName} ${worker.lastName}", fontWeight = FontWeight.Bold)
-            Text(text = "Position: ${worker.skills}")
-            Text(text = "Location: ${worker.location}")
-            Text(text = "Previous jobs: ${worker.numOfJobs}")
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier.fillMaxWidth()
+        ){
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(text = "Ime: ${worker.firstName} ${worker.lastName}", fontWeight = FontWeight.Bold)
+                Text(text = "Pozicija: ${worker.skills}")
+                Text(text = "Lokacija: ${worker.location}")
+                Text(text = "Broj poslova: ${worker.numOfJobs}")
+            }
+            Column(modifier = Modifier.padding(8.dp)
+                ) {
+                Text(text = "${worker.rating}", fontWeight = FontWeight.Bold, fontSize = 24.sp)
+
+            }
         }
+
     }
 
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -51,7 +52,7 @@ fun WorkerSearchScreen(navController: NavController) {
     )
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Worker Search Screen")
+        Text("Pronađite poziciju x")
 
 
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalArrangement = Arrangement.SpaceBetween) {
@@ -59,7 +60,7 @@ fun WorkerSearchScreen(navController: NavController) {
             ExposedDropdownMenuBox(
                 expanded = isExpandedL,
                 onExpandedChange = { viewModel.isExpandedL.value = it },
-                modifier = Modifier.fillMaxWidth(0.3f)
+                modifier = Modifier.width(128.dp)
             ) {
                 TextField(
                     value = selectedItemL,
@@ -88,7 +89,7 @@ fun WorkerSearchScreen(navController: NavController) {
             ExposedDropdownMenuBox(
                 expanded = isExpandedR,
                 onExpandedChange = { viewModel.isExpandedR.value = it },
-                modifier = Modifier.fillMaxWidth(0.4f)
+                modifier = Modifier.width(128.dp)
             ) {
                 TextField(
                     value = selectedItemR,

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -1,15 +1,13 @@
 package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
+import androidx.compose.material3.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -17,18 +15,94 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WorkerSearchScreen(navController: NavController){
+fun WorkerSearchScreen(navController: NavController) {
     val viewModel: WorkerSearchViewModel = viewModel()
-    val scrollState = rememberScrollState()
+
+
+    val isExpandedL by viewModel.isExpandedL
+    val isExpandedR by viewModel.isExpandedR
+
+    val selectedItemL by viewModel.selectedItemL
+    val selectedItemR by viewModel.selectedItemR
+
+
+    val optionsR = listOf("Ocjena ASC", "Ocjena DESC", "Broj poslova ASC", "Broj poslova DESC")
+    val optionsL = listOf("Zagrebačka", "Krapinsko-zagorska", "Sisacko-moslavačka", "Karlovačka", "Varaždinska",
+         "Bjelovarsko-bilogorska", "Primorsko-goranska", "Ličko-senjska",
+        "Virovitičko-podravska", "Osječko-baranjska", "Šibensko-kninska", "Vukovarsko-srijemska",
+        "Zadarska", "Međimurska", "Dubrovničko-neretvanska", "Istarska", "Požeško-slavonska",
+        "Splitsko-dalmatinska", "Zagrebački grad"
+    )
+
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text("Worker Search Screen")
+
+        // Left Dropdown
+        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalArrangement = Arrangement.SpaceBetween) {
+            ExposedDropdownMenuBox(
+                expanded = isExpandedL,
+                onExpandedChange = { viewModel.isExpandedL.value = it },
+                modifier = Modifier.fillMaxWidth(0.3f)
+            ) {
+                TextField(
+                    value = selectedItemL,
+                    onValueChange = {},
+                    readOnly = true,
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpandedL) },
+                    modifier = Modifier.menuAnchor()
+                )
+                ExposedDropdownMenu(
+                    expanded = isExpandedL,
+                    onDismissRequest = { viewModel.isExpandedL.value = false }
+                ) {
+                    optionsL.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option) },
+                            onClick = {
+                                viewModel.selectedItemL.value = option
+                                viewModel.isExpandedL.value = false
+                            }
+                        )
+                    }
+                }
+            }
+            ExposedDropdownMenuBox(
+                expanded = isExpandedR,
+                onExpandedChange = { viewModel.isExpandedR.value = it },
+                modifier = Modifier.fillMaxWidth(0.4f)
+            ) {
+                TextField(
+                    value = selectedItemR,
+                    onValueChange = {},
+                    readOnly = true,
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpandedL) },
+                    modifier = Modifier.menuAnchor()
+                )
+                ExposedDropdownMenu(
+                    expanded = isExpandedR,
+                    onDismissRequest = { viewModel.isExpandedL.value = false }
+                ) {
+                    optionsR.forEach { option ->
+                        DropdownMenuItem(
+                            text = { Text(option) },
+                            onClick = {
+                                viewModel.selectedItemR.value = option
+                                viewModel.isExpandedR.value = false
+                            }
+                        )
+                    }
+                }
+            }
+        }
+        
     }
 }
+
 @Preview(showBackground = true)
 @Composable
-fun WorkerSearchScreenPreview(){
+fun WorkerSearchScreenPreview() {
     val navController = rememberNavController()
     WorkerSearchScreen(navController)
 }
-

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -1,7 +1,18 @@
 package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
@@ -9,9 +20,12 @@ import androidx.navigation.compose.rememberNavController
 @Composable
 fun WorkerSearchScreen(navController: NavController){
     val viewModel: WorkerSearchViewModel = viewModel()
-
+    val scrollState = rememberScrollState()
+    Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+        Text("Worker Search Screen")
+    }
 }
-@Preview
+@Preview(showBackground = true)
 @Composable
 fun WorkerSearchScreenPreview(){
     val navController = rememberNavController()

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -6,14 +6,18 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.*
 import androidx.compose.material3.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerMock
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -26,8 +30,7 @@ fun WorkerSearchScreen(navController: NavController) {
 
     val selectedItemL by viewModel.selectedItemL
     val selectedItemR by viewModel.selectedItemR
-
-
+    val workers by viewModel.workers
     val optionsR = listOf("Ocjena ASC", "Ocjena DESC", "Broj poslova ASC", "Broj poslova DESC")
     val optionsL = listOf("Zagrebačka", "Krapinsko-zagorska", "Sisacko-moslavačka", "Karlovačka", "Varaždinska",
          "Bjelovarsko-bilogorska", "Primorsko-goranska", "Ličko-senjska",
@@ -96,10 +99,21 @@ fun WorkerSearchScreen(navController: NavController) {
                 }
             }
         }
-        
+        LazyColumn() {
+            items(workers){
+                worker -> WorkerItem(worker)
+            }
+        }
     }
 }
-
+@Composable
+fun WorkerItem(worker: WorkerMock.Worker) {
+    // Example UI for displaying worker's name and position
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(text = "Name: ${worker.firstName}", fontWeight = FontWeight.Bold)
+        Text(text = "Position: ${worker.skills}")
+    }
+}
 @Preview(showBackground = true)
 @Composable
 fun WorkerSearchScreenPreview() {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.*
 import androidx.compose.material3.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -54,7 +55,8 @@ fun WorkerSearchScreen(navController: NavController) {
                     onValueChange = {},
                     readOnly = true,
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpandedL) },
-                    modifier = Modifier.menuAnchor()
+                    modifier = Modifier.menuAnchor().fillMaxWidth(),
+                    label = { Text("Location", overflow = TextOverflow.Ellipsis, maxLines = 1) }
                 )
                 ExposedDropdownMenu(
                     expanded = isExpandedL,
@@ -81,7 +83,8 @@ fun WorkerSearchScreen(navController: NavController) {
                     onValueChange = {},
                     readOnly = true,
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpandedL) },
-                    modifier = Modifier.menuAnchor()
+                    modifier = Modifier.menuAnchor().fillMaxWidth(),
+                    label = { Text("Sort by", overflow = TextOverflow.Ellipsis, maxLines = 1) }
                 )
                 ExposedDropdownMenu(
                     expanded = isExpandedR,
@@ -109,10 +112,17 @@ fun WorkerSearchScreen(navController: NavController) {
 @Composable
 fun WorkerItem(worker: WorkerMock.Worker) {
     // Example UI for displaying worker's name and position
-    Column(modifier = Modifier.padding(16.dp)) {
-        Text(text = "Name: ${worker.firstName}", fontWeight = FontWeight.Bold)
-        Text(text = "Position: ${worker.skills}")
+    Card(
+        modifier = Modifier.fillMaxWidth().padding(4.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = "Name: ${worker.firstName} ${worker.lastName}", fontWeight = FontWeight.Bold)
+            Text(text = "Position: ${worker.skills}")
+            Text(text = "Location: ${worker.location}")
+            Text(text = "Previous jobs: ${worker.numOfJobs}")
+        }
     }
+
 }
 @Preview(showBackground = true)
 @Composable

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerMock
+import hr.foi.air.baufind.ui.components.WorkerCard
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -121,7 +122,7 @@ fun WorkerSearchScreen(navController: NavController) {
 
         ) {
             items(workers){
-                worker -> WorkerItem(worker){
+                worker -> WorkerCard(worker){
                     //Funkcija se poziva na pritiskom na radnika,| treba je promijeniti u kasnijim fazama i prilikom promjene obrišite dio komentara nakon | znaka.
                    Toast.makeText(context, "Clicked on ${worker.firstName} ${worker.lastName}", Toast.LENGTH_SHORT).show()
                }
@@ -129,36 +130,7 @@ fun WorkerSearchScreen(navController: NavController) {
         }
     }
 }
-@Composable
-fun WorkerItem(
-    worker: WorkerMock.Worker,
-    onItemClick: () -> Unit
-) {
-    // Example UI for displaying worker's name and position
-    Card(
-        modifier = Modifier.fillMaxWidth().padding(4.dp),
-        onClick = onItemClick
-    ) {
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier.fillMaxWidth()
-        ){
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text(text = "Ime: ${worker.firstName} ${worker.lastName}", fontWeight = FontWeight.Bold)
-                Text(text = "Pozicija: ${worker.skills}")
-                Text(text = "Lokacija: ${worker.location}")
-                Text(text = "Broj poslova: ${worker.numOfJobs}")
-            }
-            Column(modifier = Modifier.padding(8.dp)
-                ) {
-                Text(text = "${worker.rating}", fontWeight = FontWeight.Bold, fontSize = 24.sp)
 
-            }
-        }
-
-    }
-
-}
 @Preview(showBackground = true)
 @Composable
 fun WorkerSearchScreenPreview() {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -1,8 +1,19 @@
 package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerMock
+
 class WorkerSearchViewModel : ViewModel() {
+
+    val isExpandedL: MutableState<Boolean> = mutableStateOf(false)
+    val isExpandedR: MutableState<Boolean> = mutableStateOf(false)
+
+
+    val selectedItemL: MutableState<String> = mutableStateOf("")
+    val selectedItemR: MutableState<String> = mutableStateOf("")
+
     val workers: MutableLiveData<List<WorkerMock.Worker>> = MutableLiveData(WorkerMock.workers)
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -1,0 +1,8 @@
+package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class WorkerSearchViewModel : ViewModel() {
+
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -2,7 +2,7 @@ package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-
+import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerMock
 class WorkerSearchViewModel : ViewModel() {
-
+    val workers: MutableLiveData<List<WorkerMock.Worker>> = MutableLiveData(WorkerMock.workers)
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -15,5 +15,5 @@ class WorkerSearchViewModel : ViewModel() {
     val selectedItemL: MutableState<String> = mutableStateOf("")
     val selectedItemR: MutableState<String> = mutableStateOf("")
 
-    val workers: MutableLiveData<List<WorkerMock.Worker>> = MutableLiveData(WorkerMock.workers)
+    val workers: MutableState<List<WorkerMock.Worker>> = mutableStateOf(WorkerMock.workers)
 }


### PR DESCRIPTION
Sukladno dogovoru s timom, pull request prilažem ranije kako bi diskutirali samu logiku servisa koji će biti povezani s ovim ekranima i kako ne bi došlo do konflikata u međuvremenu. Trenutačno ovaj pull request ima samo izgled, no nakon sastanka će se kreirati i logika za filtriranje po županijama i drugim filterima poput ocjene i broj poslova. Implementirane su također i dropdown liste, no dodatnim istraživanjem Material dizajna dolazimo do spoznaje da dropdown liste s manjim brojem elemenata poput filteri ocjena i broja poslova preporučava se korištenje Chipova, no to ćemo kasnije diskutirati. Trenutačno s Mock podacima ekran za pretraživanje radnika izgleda ovako:
![Snimka zaslona 2024-11-19 184439](https://github.com/user-attachments/assets/e2ac4a19-c89c-4eb9-a2e6-59a1395178e0)

![Snimka zaslona 2024-11-19 181453](https://github.com/user-attachments/assets/f898d537-83e0-4046-8318-1d12998ed494)

