### PR TITLE
Bauf 74 kreiranje backend logike za prijavu

### DIFF
--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/GetAllUsers/GetAllUsersResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/GetAllUsers/GetAllUsersResponse.cs
@@ -1,9 +1,9 @@
-﻿namespace BusinessLogicLayer.AppLogic.Users;
+﻿namespace BusinessLogicLayer.AppLogic.Users.GetAllUsers;
 
 /// <summary>
 /// Ovo je odgovor koji se šalje preko API zahtjeva za dobivanje svih korisnika
 /// </summary>
-public class GetAllUsersResponse
+public record GetAllUsersResponse
 {
     public List<UserRecord> Users { get; set; } = new List<UserRecord>();
 

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/GetUser/GetUserResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/GetUser/GetUserResponse.cs
@@ -1,9 +1,9 @@
-﻿namespace BusinessLogicLayer.AppLogic.Users;
+﻿namespace BusinessLogicLayer.AppLogic.Users.GetUser;
 
 /// <summary>
 /// Ovo je odgovor koji se šalje preko API zahtjeva za dobivanje jednog korisnika
 /// </summary>
-public class GetUserResponse
+public record GetUserResponse
 {
     public UserRecord? User { get; set; } = null;
     public string? Error { get; set; } = string.Empty;

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/IUserService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/IUserService.cs
@@ -1,5 +1,6 @@
 ﻿using BusinessLogicLayer.AppLogic.Users.GetAllUsers;
 using BusinessLogicLayer.AppLogic.Users.GetUser;
+using BusinessLogicLayer.AppLogic.Users.Login;
 using BusinessLogicLayer.AppLogic.Users.RegisterUser;
 
 namespace BusinessLogicLayer.AppLogic.Users;
@@ -26,7 +27,14 @@ public interface IUserService
     /// <summary>
     /// Metoda za registriranje novog korisnika
     /// </summary>
-    /// <param name="command">podaci za registraciju</param>
-    /// <returns>korisnik i poruka uspjeha ako je registracija uspješna, u protivnom poruka greške</returns>
-    public RegisterUserResponse RegisterUser(RegisterUserRequest command);
+    /// <param name="request">podaci za registraciju</param>
+    /// <returns>poruka uspjeha ako je registracija uspješna, u protivnom poruka greške</returns>
+    public RegisterUserResponse RegisterUser(RegisterUserRequest request);
+
+    /// <summary>
+    /// Metoda za prijavu postojećeg korisnika
+    /// </summary>
+    /// <param name="request">podaci za prijavu</param>
+    /// <returns>token ako je uspješno registriran, a ako ne, onda poruku greške</returns>
+    public LoginResponse Login(LoginRequest request);
 }

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/IUserService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/IUserService.cs
@@ -1,4 +1,6 @@
-﻿using BusinessLogicLayer.AppLogic.Users.RegisterUser;
+﻿using BusinessLogicLayer.AppLogic.Users.GetAllUsers;
+using BusinessLogicLayer.AppLogic.Users.GetUser;
+using BusinessLogicLayer.AppLogic.Users.RegisterUser;
 
 namespace BusinessLogicLayer.AppLogic.Users;
 
@@ -26,5 +28,5 @@ public interface IUserService
     /// </summary>
     /// <param name="command">podaci za registraciju</param>
     /// <returns>korisnik i poruka uspjeha ako je registracija uspješna, u protivnom poruka greške</returns>
-    public RegisterUserResponse RegisterUser(RegisterUserCommand command);
+    public RegisterUserResponse RegisterUser(RegisterUserRequest command);
 }

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/Login/LoginRequest.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/Login/LoginRequest.cs
@@ -1,0 +1,10 @@
+﻿namespace BusinessLogicLayer.AppLogic.Users.Login;
+
+/// <summary>
+/// Ovi podaci se šalju kod prijave korisnika
+/// </summary>
+public record LoginRequest
+{
+    public string Email { get; set; }
+    public string Password { get; set; }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/Login/LoginResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/Login/LoginResponse.cs
@@ -1,0 +1,11 @@
+﻿namespace BusinessLogicLayer.AppLogic.Users.Login;
+
+/// <summary>
+/// Odgovor API-ja na uspješnu prijavu
+/// </summary>
+public record LoginResponse
+{
+    public string? Success { get; set; } = string.Empty;
+    public string? JWT { get; set; } = null; // TODO: implementirati JWT
+    public string? Error { get; set; } = string.Empty;
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/Login/LoginValidator.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/Login/LoginValidator.cs
@@ -1,0 +1,22 @@
+﻿using FluentValidation;
+
+namespace BusinessLogicLayer.AppLogic.Users.Login;
+
+/// <summary>
+/// Validira prenesene podatke za prijavu
+/// </summary>
+public class LoginValidator : AbstractValidator<LoginRequest>
+{
+    /// <summary>
+    /// Validacija napisana u konstruktur klase
+    /// </summary>
+    public LoginValidator()
+    {
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("Lozinka je obavezna");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email mora biti unesen")
+            .Matches(@"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$").WithMessage("Unesite validan email");
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/RegisterUser/RegisterUserRequest.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/RegisterUser/RegisterUserRequest.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Ovi podaci se šalju kod registracije novog korisnika
 /// </summary>
-public class RegisterUserCommand
+public record RegisterUserRequest
 {
     public string Name { get; set; }
     public string Email { get; set; }

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/RegisterUser/RegisterUserResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/RegisterUser/RegisterUserResponse.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Odgovor API-ja na registraciju novog korisnika
 /// </summary>
-public class RegisterUserResponse
+public record RegisterUserResponse
 {
     public string? Success { get; set; } = string.Empty;
     public UserRecord? User { get; set; } = null;

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/RegisterUser/RegisterUserResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/RegisterUser/RegisterUserResponse.cs
@@ -6,6 +6,5 @@
 public record RegisterUserResponse
 {
     public string? Success { get; set; } = string.Empty;
-    public UserRecord? User { get; set; } = null;
     public string? Error { get; set; } = string.Empty;
 }

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/RegisterUser/RegisterUserValidator.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/RegisterUser/RegisterUserValidator.cs
@@ -1,0 +1,49 @@
+﻿using DataAccessLayer.AppLogic;
+using FluentValidation;
+
+namespace BusinessLogicLayer.AppLogic.Users.RegisterUser;
+
+/// <summary>
+/// Klasa koja validira request koji se šalje kod registracije usera
+/// Ove validacije bi trebale sve proći, jer na frontendu trebaju postojati iste, no ako se slučajno zaobiđu, ovdje također moraju biti
+/// </summary>
+public class RegisterUserValidator : AbstractValidator<RegisterUserRequest>
+{
+    /// <summary>
+    /// Validacija napisana u konstruktor klase
+    /// </summary>
+    /// <param name="_repository">Repozitorij proslijeđen iz servisne klase</param>
+    public RegisterUserValidator(IUserRepository _repository)
+    {
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("Lozinka je obavezna");
+
+        RuleFor(x => x.RepeatPassword)
+            .Equal(x => x.Password).WithMessage("Lozinke se ne podudaraju");
+
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Ime je obavezno")
+            .MaximumLength(100).WithMessage("Korisničko ime ne smije prelaziti 100 znakova");
+
+        RuleFor(x => x.Address)
+            .NotEmpty().WithMessage("Adresa je obavezna")
+            .MaximumLength(100).WithMessage("Adresa ne smije prelaziti 100 znakova");
+
+        RuleFor(x => x.Phone)
+            .NotEmpty().WithMessage("Broj telefona je obavezan")
+            .MaximumLength(100).WithMessage("Broj telefona ne smije prelaziti 100 znakova");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email mora biti unesen")
+            .MaximumLength(100).WithMessage("Email ne smije prelaziti 100 znakova")
+            .Matches(@"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$").WithMessage("Unesite validan email")
+            .Custom((email, context) =>
+            {
+                var users = _repository.GetUsers();
+                if (users.Any(u => u.Email == email))
+                {
+                    context.AddFailure("Email adresa već postoji");
+                }
+            });
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/UserService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/UserService.cs
@@ -133,18 +133,7 @@ public class UserService : IUserService
 
         return new RegisterUserResponse()
         {
-            Success = $"Korisnik s e mail adresom {user!.Email} uspješno je registriran.",
-            User = new UserRecord()
-            {
-                Id = user.Id,
-                Name = user.Name,
-                Email = user.Email,
-                Phone = user.Phone,
-                Joined = user.Joined,
-                Address = user.Address,
-                ProfilePicture = user.ProfilePicture,
-                Deleted = user.Deleted
-            }
+            Success = $"Korisnik s e mail adresom {user!.Email} uspješno je registriran."
         };
     }
 

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/UserService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/UserService.cs
@@ -1,4 +1,6 @@
 ﻿using BusinessLogicLayer.AppLogic.Users;
+using BusinessLogicLayer.AppLogic.Users.GetAllUsers;
+using BusinessLogicLayer.AppLogic.Users.GetUser;
 using BusinessLogicLayer.AppLogic.Users.RegisterUser;
 using DataAccessLayer.AppLogic;
 using DataAccessLayer.Models;
@@ -94,7 +96,7 @@ public class UserService : IUserService
     /// </summary>
     /// <param name="command">podaci za registraciju</param>
     /// <returns>korisnik i poruka uspjeha ako je registracija uspješna, u protivnom poruka greške</returns>
-    public RegisterUserResponse RegisterUser(RegisterUserCommand command)
+    public RegisterUserResponse RegisterUser(RegisterUserRequest command)
     {
         var errors = ValidateUserRegistration(command);
         if (errors.Any())
@@ -151,7 +153,7 @@ public class UserService : IUserService
     /// </summary>
     /// <param name="command">proslijeđena iz registracije</param>
     /// <returns>praznu listu, ili listu grešaka</returns>
-    private List<string> ValidateUserRegistration(RegisterUserCommand command)
+    private List<string> ValidateUserRegistration(RegisterUserRequest command)
     {
         List<string> errors = new List<string>();
         

--- a/Software/Backend/WebApi/Controllers/UserController.cs
+++ b/Software/Backend/WebApi/Controllers/UserController.cs
@@ -1,6 +1,7 @@
 ﻿using BusinessLogicLayer.AppLogic.Users;
 using BusinessLogicLayer.AppLogic.Users.GetAllUsers;
 using BusinessLogicLayer.AppLogic.Users.GetUser;
+using BusinessLogicLayer.AppLogic.Users.Login;
 using BusinessLogicLayer.AppLogic.Users.RegisterUser;
 using Microsoft.AspNetCore.Mvc;
 
@@ -47,9 +48,9 @@ public class UserController : ControllerBase
 
     // POST: /users/register
     [HttpPost("register")]
-    public ActionResult<RegisterUserResponse> RegisterUser(RegisterUserRequest command)
+    public ActionResult<RegisterUserResponse> RegisterUser(RegisterUserRequest request)
     {
-        var newUser = _userService.RegisterUser(command);
+        var newUser = _userService.RegisterUser(request);
 
         if (newUser == null || !string.IsNullOrEmpty(newUser.Error))
         {
@@ -57,5 +58,19 @@ public class UserController : ControllerBase
         }
 
         return newUser;
+    }
+
+    // POST: /users/login
+    [HttpPost("login")]
+    public ActionResult<LoginResponse> Login(LoginRequest request)
+    {
+        var user = _userService.Login(request);
+
+        if (!string.IsNullOrEmpty(user.Error))
+        {
+            return BadRequest(user);
+        }
+
+        return user;
     }
 }

--- a/Software/Backend/WebApi/Controllers/UserController.cs
+++ b/Software/Backend/WebApi/Controllers/UserController.cs
@@ -1,4 +1,6 @@
 ﻿using BusinessLogicLayer.AppLogic.Users;
+using BusinessLogicLayer.AppLogic.Users.GetAllUsers;
+using BusinessLogicLayer.AppLogic.Users.GetUser;
 using BusinessLogicLayer.AppLogic.Users.RegisterUser;
 using Microsoft.AspNetCore.Mvc;
 
@@ -45,7 +47,7 @@ public class UserController : ControllerBase
 
     // POST: /users/register
     [HttpPost("register")]
-    public ActionResult<RegisterUserResponse> RegisterUser(RegisterUserCommand command)
+    public ActionResult<RegisterUserResponse> RegisterUser(RegisterUserRequest command)
     {
         var newUser = _userService.RegisterUser(command);
 


### PR DESCRIPTION
### Ukratko

Ovaj PR rješava sljedeći task: https://vlovric21.atlassian.net/browse/BAUF-74

Napisana je backend logika za prijavu. Sad je moguće na API putanju /user/login poslati korisničko ime i lozinku i ako su ispravni, vrati se poruka uspjeha (I KASNIJE TOKEN). Ako lozinka nije točna ili e mail ne postoji, vrati se poruka greške.

Najbolje isprobati koristeći _Swagger UI_:
![image](https://github.com/user-attachments/assets/8b1000ce-050e-4e9b-92bf-07c5a4d0adbb)

### Što je još napravljeno

**Validacija je prebačena iz servisne klase u FluentValidation.** Kako se koristi:
1. Napravite klasu koja nasljeđuje AbstractValidator<MODEL_KOJI_VALIDIRATE>, kao što je sljedeće:
![image](https://github.com/user-attachments/assets/dd3cf233-7fcd-447c-8b25-7fbb4f7494f2)
2. U konstruktor pišite validaciju koristeći metode od Fluent Validation. Metode možete naći na: https://docs.fluentvalidation.net/en/latest/built-in-validators.html
3. Iskoristite validator u servisnoj klasi:
![image](https://github.com/user-attachments/assets/9cc4145a-f2d4-4cf4-887e-7a915f656d6f)

Za sada nisam validatore ubacivao s DI, jer trebaju samo servisnoj klasi pa je ovo u redu.

Malo je i refaktorirana struktura foldera i nazivi radi lakšeg snalaženja. Modeli vezani uz API zahtjev su imenovani s "Request" i "Response" i u svojoj su mapi:
![image](https://github.com/user-attachments/assets/3b28c011-8161-4255-adb3-d0ffca79005d)
**Bitno: ovo je refaktoriranje SAMO u kodu, API putanje i pozivi NISU se mijenjali (osim vraćanja korisnika kod registracije):**

@fsimic21 maknuo sam vraćanje korisnika kod uspješne registracije, pa kad se ovo odobri i mergea u develop, mergeaj u svoju granu da možeš nastaviti raditi kako si i krenuo.

Nakon što se ovo mergea, pozabavit ću se s JWT-om na backendu.