### PR TITLE
BAUF-67 Implementacija JWT

### DIFF
--- a/Software/Backend/BusinessLogicLayer/AppLogic/IJwtService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/IJwtService.cs
@@ -1,0 +1,16 @@
+﻿using BusinessLogicLayer.AppLogic.Users;
+
+namespace BusinessLogicLayer.AppLogic;
+
+/// <summary>
+/// Servis za generiranje, provjeravanje i korištenje JWT-ova
+/// </summary>
+public interface IJwtService
+{
+    /// <summary>
+    /// Vraća JWT token za korisnika
+    /// </summary>
+    /// <param name="user">korisnik</param>
+    /// <returns>JWT</returns>
+    public string GenerateToken(UserRecord user);
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Users/Login/LoginResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Users/Login/LoginResponse.cs
@@ -6,6 +6,6 @@
 public record LoginResponse
 {
     public string? Success { get; set; } = string.Empty;
-    public string? JWT { get; set; } = null; // TODO: implementirati JWT
+    public string? JWT { get; set; } = null;
     public string? Error { get; set; } = string.Empty;
 }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JwtService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JwtService.cs
@@ -1,0 +1,55 @@
+﻿using BusinessLogicLayer.AppLogic;
+using BusinessLogicLayer.AppLogic.Users;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace BusinessLogicLayer.Infrastructure;
+
+/// <summary>
+/// Implementacija servisa za generiranje, provjeravanje i korištenje JWT-ova
+/// </summary>
+public class JwtService : IJwtService
+{
+    private readonly byte[] _keyBytes;
+    private readonly string _issuer;
+    private readonly string _audience;
+
+    public JwtService(IOptions<JWTOptions> options)
+    {
+        _keyBytes = Encoding.ASCII.GetBytes(options.Value.Key);
+        _issuer = options.Value.Issuer;
+        _audience = options.Value.Audience;
+    }
+
+    /// <summary>
+    /// Vraća JWT token za korisnika
+    /// </summary>
+    /// <param name="user">korisnik</param>
+    /// <returns>JWT</returns>
+    public string GenerateToken(UserRecord user)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(JwtRegisteredClaimNames.Email, user.Email)
+        };
+
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(claims),
+            Expires = DateTime.UtcNow.AddMinutes(30),
+            Issuer = _issuer,
+            Audience = _audience,
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(_keyBytes), SecurityAlgorithms.HmacSha256Signature)
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/UserService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/UserService.cs
@@ -1,4 +1,5 @@
-﻿using BusinessLogicLayer.AppLogic.Users;
+﻿using BusinessLogicLayer.AppLogic;
+using BusinessLogicLayer.AppLogic.Users;
 using BusinessLogicLayer.AppLogic.Users.GetAllUsers;
 using BusinessLogicLayer.AppLogic.Users.GetUser;
 using BusinessLogicLayer.AppLogic.Users.Login;
@@ -18,10 +19,12 @@ namespace BusinessLogicLayer.Infrastructure;
 public class UserService : IUserService
 {
     private readonly IUserRepository _repository;
+    private readonly IJwtService _jwtService;
 
-    public UserService(IUserRepository repository)
+    public UserService(IUserRepository repository, IJwtService jwtService)
     {
         _repository = repository;
+        _jwtService = jwtService;
     }
 
     /// <summary>
@@ -174,9 +177,15 @@ public class UserService : IUserService
             };
         }
 
+        var newUser = new UserRecord()
+        {
+            Id = user.Id,
+            Email = user.Email
+        };
+
         return new LoginResponse()
         {
-            JWT = "", // TODO: izračunaj JWT
+            JWT = _jwtService.GenerateToken(newUser),
             Success = $"Korisnik {user.Name} uspješno je prijavljen u sustav."
         };
     }

--- a/Software/Backend/BusinessLogicLayer/JWTOptions.cs
+++ b/Software/Backend/BusinessLogicLayer/JWTOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace BusinessLogicLayer;
+
+/// <summary>
+/// Klasa za ubacivanje JWT ključa, issuer i audience
+/// Pogledati: https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/options?view=aspnetcore-9.0
+/// </summary>
+public class JWTOptions
+{
+    public string Key { get; set; } = string.Empty;
+    public string Issuer { get; set; } = string.Empty;
+    public string Audience { get; set; } = string.Empty;
+}

--- a/Software/Backend/BusinessLogicLayer/ServiceCollectionExtensions.cs
+++ b/Software/Backend/BusinessLogicLayer/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using BusinessLogicLayer.AppLogic.Users;
+﻿using BusinessLogicLayer.AppLogic;
+using BusinessLogicLayer.AppLogic.Users;
 using BusinessLogicLayer.Infrastructure;
 using DataAccessLayer;
 using DataAccessLayer.AppLogic;
@@ -21,6 +22,9 @@ public static class ServiceCollectionExtensions
         services.Configure<DBOptions>(
             configuration.GetSection("Database")
         );
+        services.Configure<JWTOptions>(
+            configuration.GetSection("JWTOptions")
+        );
 
         services.AddScoped<DB>(); // Zbog DI u repozitorije
 
@@ -28,6 +32,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IUserRepository, UserRepository>();
 
         // Servisi
+        services.AddScoped<IJwtService, JwtService>();
         services.AddScoped<IUserService, UserService>();
 
         return services;

--- a/Software/Backend/WebApi/Controllers/UserController.cs
+++ b/Software/Backend/WebApi/Controllers/UserController.cs
@@ -3,6 +3,7 @@ using BusinessLogicLayer.AppLogic.Users.GetAllUsers;
 using BusinessLogicLayer.AppLogic.Users.GetUser;
 using BusinessLogicLayer.AppLogic.Users.Login;
 using BusinessLogicLayer.AppLogic.Users.RegisterUser;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace WebApi.Controllers;
@@ -20,6 +21,7 @@ public class UserController : ControllerBase
 
     // GET: /users
     [HttpGet]
+    [Authorize]
     public ActionResult<GetAllUsersResponse> GetAll()
     {
         var users = _userService.GetAllUsers();

--- a/Software/Backend/WebApi/Controllers/UserController.cs
+++ b/Software/Backend/WebApi/Controllers/UserController.cs
@@ -36,8 +36,19 @@ public class UserController : ControllerBase
 
     // GET: /users/{id}
     [HttpGet("{id}")]
+    [Authorize]
     public ActionResult<GetUserResponse> GetUser(int id)
     {
+        var userIdFromJwt = HttpContext.Items["UserId"] as int?;
+
+        if (userIdFromJwt == null || userIdFromJwt != id)
+        {
+            return Unauthorized(new GetUserResponse()
+            {
+                Error = "Ne možete pristupiti tom resursu!"
+            });
+        } 
+
         var user = _userService.GetOneUser(id);
 
         if (user.User == null)
@@ -50,6 +61,7 @@ public class UserController : ControllerBase
 
     // POST: /users/register
     [HttpPost("register")]
+    [AllowAnonymous]
     public ActionResult<RegisterUserResponse> RegisterUser(RegisterUserRequest request)
     {
         var newUser = _userService.RegisterUser(request);
@@ -64,6 +76,7 @@ public class UserController : ControllerBase
 
     // POST: /users/login
     [HttpPost("login")]
+    [AllowAnonymous]
     public ActionResult<LoginResponse> Login(LoginRequest request)
     {
         var user = _userService.Login(request);

--- a/Software/Backend/WebApi/Middleware/JwtMiddleware.cs
+++ b/Software/Backend/WebApi/Middleware/JwtMiddleware.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using System.Security.Claims;
+
+namespace WebApi.Middleware;
+
+/// <summary>
+/// Middleware koji vadi korisnikov ID iz JWT-a za korištenje na API endpointima
+/// </summary>
+public class JwtMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public JwtMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        var endpoint = context.GetEndpoint();
+        if (endpoint?.Metadata?.GetMetadata<AllowAnonymousAttribute>() != null)
+        {
+            await _next(context);
+            return;
+        }
+
+        var userIdClaim = context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+        if (userIdClaim == null || !int.TryParse(userIdClaim, out var userId))
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync("Nemate pristup.");
+            return;
+        }
+
+        context.Items["UserId"] = userId;
+
+        await _next(context);
+    }
+}

--- a/Software/Backend/WebApi/Program.cs
+++ b/Software/Backend/WebApi/Program.cs
@@ -1,5 +1,8 @@
-
 using BusinessLogicLayer;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using System.Text;
 
 namespace WebApi;
 
@@ -15,6 +18,54 @@ public class Program
 
         builder.Services.AddDataAccessLayerServices(builder.Configuration);
 
+        builder.Services.AddAuthorization();
+
+        var jwtOptions = builder.Configuration.GetSection("JWTOptions").Get<JWTOptions>();
+        var jwtKeyBytes = Encoding.ASCII.GetBytes(jwtOptions!.Key);
+
+        builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(x =>
+            {
+                x.TokenValidationParameters = new TokenValidationParameters
+                {
+                    IssuerSigningKey = new SymmetricSecurityKey(jwtKeyBytes),
+                    ValidIssuer = jwtOptions.Issuer,
+                    ValidAudience = jwtOptions.Audience,
+                    ValidateIssuerSigningKey = true,
+                    ValidateLifetime = true,
+                    ValidateIssuer = true,
+                    ValidateAudience = true
+                };
+            });
+
+        builder.Services.AddSwaggerGen(option =>
+        {
+            option.SwaggerDoc("v1", new OpenApiInfo { Title = "Baufind API", Version = "v1" });
+            option.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+            {
+                In = ParameterLocation.Header,
+                Description = "Unesite validan token",
+                Name = "Authorization",
+                Type = SecuritySchemeType.Http,
+                BearerFormat = "JWT",
+                Scheme = "Bearer"
+            });
+            option.AddSecurityRequirement(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type=ReferenceType.SecurityScheme,
+                            Id="Bearer"
+                        }
+                    },
+                    new string[]{}
+                }
+            });
+        });
+
         var app = builder.Build();
 
         if (app.Environment.IsDevelopment())
@@ -25,6 +76,7 @@ public class Program
 
         app.UseHttpsRedirection();
 
+        app.UseAuthentication();
         app.UseAuthorization();
 
         app.MapControllers();

--- a/Software/Backend/WebApi/Program.cs
+++ b/Software/Backend/WebApi/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using System.Text;
+using WebApi.Middleware;
 
 namespace WebApi;
 
@@ -78,6 +79,8 @@ public class Program
 
         app.UseAuthentication();
         app.UseAuthorization();
+
+        app.UseMiddleware<JwtMiddleware>();
 
         app.MapControllers();
 

--- a/Software/Backend/WebApi/WebApi.csproj
+++ b/Software/Backend/WebApi/WebApi.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.11" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/Software/Backend/WebApi/appsettings.Development.json
+++ b/Software/Backend/WebApi/appsettings.Development.json
@@ -7,5 +7,10 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "JWTOptions": {
+    "Key": "OvoTrebaPromijenitiHitno!!!JakoHitnoOvoPohranitiNegdjeDrugdje...",
+    "Issuer": "Baufind",
+    "Audience": "Baufind Android app"
   }
 }


### PR DESCRIPTION
Ovo rješava sljedeći issue: https://vlovric21.atlassian.net/browse/BAUF-67

### Što je napravljeno

Implementiran je JWT na backendu. JWT se dobiva kod prijave:

![image](https://github.com/user-attachments/assets/d9462f3e-ce35-45da-ad79-62ad54000bb7)

### Kako koristiti?

Da bi putanja zahtijevala JWT, potrebno je samo dodati _[Authorize]_ iznad definiranja API poziva:

![image](https://github.com/user-attachments/assets/4a7ebead-605f-4f28-b2cc-07387635a1fc)

Taj poziv sada neće raditi ukoliko se ne šalje validan JWT. Ne trebate ga slati, to je napravljeno na frontendu već: https://github.com/AIR-DavidoviTigrovi/baufind/pull/14

No ovo ne provjerava sadržaj JWT-a, već samo da postoji JWT. Da bi se iz JWT-a pročitao ID korisnika (da se provjeri da npr. on želi dohvatiti samo svoje podatke, ili da mu se automatski vrate njegovi podaci), napravljen je middleware koji se koristi na sljedeći način:

![image](https://github.com/user-attachments/assets/8df928ee-2608-453c-9382-f0d0fe63e743)

### Kako istestirati u Swaggeru?

Kod uspješne prijave preko putanje za prijavu, dobiva se JWT:

![image](https://github.com/user-attachments/assets/d9462f3e-ce35-45da-ad79-62ad54000bb7)

Potrebno je kliknuti na gumb _Authorize_:

![image](https://github.com/user-attachments/assets/a410c6d8-5bc9-45ed-b80a-a5bf08d16609)

Zatim se JWT iz prijave zalijepi i klikne se na drugi gumb _Authorize_:

![image](https://github.com/user-attachments/assets/da7d59bb-78d6-48e6-8ea6-87f33e04cead)

Sada će Swagger kod svakog zahtjeva slati JWT.