### PR TITLE
Bauf 57 implementiranje ekrana za kreiranje posla

### DIFF
--- a/Software/Frontend/app/build.gradle.kts
+++ b/Software/Frontend/app/build.gradle.kts
@@ -58,4 +58,6 @@ dependencies {
     androidTestImplementation(libs.androidx.ui.test.junit4)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    implementation("io.coil-kt.coil3:coil-compose:3.0.4")
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -51,7 +51,7 @@ class MainActivity : ComponentActivity() {
                     ) {
                         NavHost(
                             navController = navController,
-                            startDestination = "jobDetailsScreen"
+                            startDestination = "login"
                         ) {
                             composable("login") { LoginScreen(navController) }
                             composable("registration") { RegistrationScreen(navController) }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.navigation.BottomNavigationBar
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
+import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobPositionsLocationScreen
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
 import hr.foi.air.baufind.ui.screens.WorkerSearchScreen.WorkerSearchScreen
 import hr.foi.air.baufind.ui.theme.BaufindTheme
@@ -52,7 +53,7 @@ class MainActivity : ComponentActivity() {
                             composable("registration") { RegistrationScreen(navController) }
                             composable("workersSearchScreen") { WorkerSearchScreen(navController) }
                             composable("jobDetailsScreen") { JobDetailsScreen(navController) }
-                            //composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController) }
+                            composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController) }
                             //composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController) }
                         }
                     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -19,6 +20,7 @@ import hr.foi.air.baufind.navigation.BottomNavigationBar
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobAddSkillsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobPositionsLocationScreen
+import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobViewModel
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
 import hr.foi.air.baufind.ui.screens.WorkerSearchScreen.WorkerSearchScreen
 import hr.foi.air.baufind.ui.theme.BaufindTheme
@@ -28,6 +30,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
+            val jobViewModel : JobViewModel = viewModel()
             val navController = rememberNavController()
             val currentRoute = navController
                 .currentBackStackEntryAsState().value?.destination?.route
@@ -53,9 +56,9 @@ class MainActivity : ComponentActivity() {
                             composable("login") { LoginScreen(navController) }
                             composable("registration") { RegistrationScreen(navController) }
                             composable("workersSearchScreen") { WorkerSearchScreen(navController) }
-                            composable("jobDetailsScreen") { JobDetailsScreen(navController) }
-                            composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController) }
-                            composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController) }
+                            composable("jobDetailsScreen") { JobDetailsScreen(navController, jobViewModel) }
+                            composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController, jobViewModel) }
+                            composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel) }
                         }
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.navigation.BottomNavigationBar
+import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobAddSkillsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobPositionsLocationScreen
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
@@ -54,7 +55,7 @@ class MainActivity : ComponentActivity() {
                             composable("workersSearchScreen") { WorkerSearchScreen(navController) }
                             composable("jobDetailsScreen") { JobDetailsScreen(navController) }
                             composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController) }
-                            //composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController) }
+                            composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController) }
                         }
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.navigation.BottomNavigationBar
+import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
 import hr.foi.air.baufind.ui.screens.WorkerSearchScreen.WorkerSearchScreen
 import hr.foi.air.baufind.ui.theme.BaufindTheme
@@ -50,6 +51,9 @@ class MainActivity : ComponentActivity() {
                             composable("login") { LoginScreen(navController) }
                             composable("registration") { RegistrationScreen(navController) }
                             composable("workersSearchScreen") { WorkerSearchScreen(navController) }
+                            composable("jobDetailsScreen") { JobDetailsScreen(navController) }
+                            //composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController) }
+                            //composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController) }
                         }
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
                     ) {
                         NavHost(
                             navController = navController,
-                            startDestination = "login"
+                            startDestination = "jobDetailsScreen"
                         ) {
                             composable("login") { LoginScreen(navController) }
                             composable("registration") { RegistrationScreen(navController) }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PictureItem.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PictureItem.kt
@@ -14,6 +14,6 @@ fun PictureItem(imageUri: Uri) {
     AsyncImage(
         model = imageUri,
         contentDescription = null,
-        modifier = Modifier.size(100.dp)
+        modifier = Modifier.size(200.dp)
     )
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PictureItem.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PictureItem.kt
@@ -1,0 +1,17 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PictureItem(drawableId: Int) {
+    Image(
+        painter = painterResource(id = drawableId),
+        contentDescription = null,
+        modifier = Modifier.size(100.dp)
+    )
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PictureItem.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PictureItem.kt
@@ -1,16 +1,18 @@
 package hr.foi.air.baufind.ui.components
 
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 
 @Composable
-fun PictureItem(drawableId: Int) {
-    Image(
-        painter = painterResource(id = drawableId),
+fun PictureItem(imageUri: Uri) {
+    AsyncImage(
+        model = imageUri,
         contentDescription = null,
         modifier = Modifier.size(100.dp)
     )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PositionAndNumber.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PositionAndNumber.kt
@@ -20,10 +20,9 @@ import androidx.compose.ui.Modifier
 @Composable
 fun PositionAndNumber(
     text: String,
-    initialCount: Int = 0,
+    count: Int,
     onCountChange: (Int) -> Unit
 ) {
-    var count by remember { mutableStateOf(initialCount) }
 
     Row(
         modifier = Modifier.fillMaxWidth(),

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PositionAndNumber.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PositionAndNumber.kt
@@ -1,11 +1,16 @@
 package hr.foi.air.baufind.ui.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -16,28 +21,45 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun PositionAndNumber(
     text: String,
     count: Int,
-    onCountChange: (Int) -> Unit
+    onCountChange: (Int) -> Unit,
+    onDelete: () -> Unit
 ) {
 
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(Color.LightGray)
+            .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
+            .padding(8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(text = text)
 
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            IconButton(onClick = { onCountChange(count -1) }) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = {
+                if(count > 1){
+                    onCountChange(count - 1)
+                }
+            }
+            ) {
                 Icon(imageVector = Icons.Filled.Clear, contentDescription = "Minus")
             }
             Text(text = count.toString())
             IconButton(onClick = { onCountChange(count + 1) }) {
                 Icon(imageVector = Icons.Filled.Add, contentDescription = "Plus")
+            }
+            IconButton(onClick = onDelete) {
+                Icon(imageVector = Icons.Filled.Delete, contentDescription = "Delete")
             }
         }
     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PositionAndNumber.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/PositionAndNumber.kt
@@ -1,0 +1,45 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun PositionAndNumber(
+    text: String,
+    initialCount: Int = 0,
+    onCountChange: (Int) -> Unit
+) {
+    var count by remember { mutableStateOf(initialCount) }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(text = text)
+
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = { onCountChange(count -1) }) {
+                Icon(imageVector = Icons.Filled.Clear, contentDescription = "Minus")
+            }
+            Text(text = count.toString())
+            IconButton(onClick = { onCountChange(count + 1) }) {
+                Icon(imageVector = Icons.Filled.Add, contentDescription = "Plus")
+            }
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/SkillListConfirm.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/SkillListConfirm.kt
@@ -1,0 +1,55 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SkillListConfirm(
+    text: String,
+    onConfirmClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.LightGray)
+            .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(text = text)
+
+        IconButton(
+            onClick = onConfirmClick,
+            modifier = Modifier
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary)
+                .padding(1.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Check,
+                contentDescription = "Confirm",
+                tint = Color.White
+            )
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
@@ -1,14 +1,77 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import hr.foi.air.baufind.ui.components.PrimaryTextField
+import hr.foi.air.baufind.ui.components.SkillListConfirm
+import kotlin.text.contains
 
 //ekran za dodavanje uloga koje su potrebne za posao
 @Composable
 fun JobAddSkillsScreen(navController: NavController){
+    var searchText by remember { mutableStateOf("") }
+    val myStrings = listOf("Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
+        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5")
 
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(22.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        PrimaryTextField(
+            value = searchText,
+            onValueChange = { searchText = it },
+            label = "Pretraži",
+            modifier = Modifier.fillMaxWidth(),
+            isError = false
+        )
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(22.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(myStrings.filter { it.contains(searchText, ignoreCase = true) }) { text ->
+                SkillListConfirm(
+                    text = text,
+                    onConfirmClick = {
+                        //prenosi na prošli ekran
+                    }
+                )
+            }
+        }
+    }
 }
 
 @Preview(showBackground = true)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -54,7 +55,7 @@ fun JobAddSkillsScreen(navController: NavController, jobViewModel: JobViewModel)
                 SkillListConfirm(
                     text = text,
                     onConfirmClick = {
-                        jobViewModel.jobPositions.add(JobPosition(text, 1))
+                        jobViewModel.jobPositions.add(JobPosition(text, mutableIntStateOf(1)))
                         navController.popBackStack()
                     }
                 )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
@@ -24,22 +24,10 @@ import hr.foi.air.baufind.ui.components.PrimaryTextField
 import hr.foi.air.baufind.ui.components.SkillListConfirm
 import kotlin.text.contains
 
-//ekran za dodavanje uloga koje su potrebne za posao
 @Composable
-fun JobAddSkillsScreen(navController: NavController){
+fun JobAddSkillsScreen(navController: NavController, jobViewModel: JobViewModel){
     var searchText by remember { mutableStateOf("") }
-    val myStrings = listOf("Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5",
-        "Pozicija 1", "Pozicija 2", "Pozicija 3", "Pozicija 4", "Pozicija 5")
+    val myStrings = listOf("Pozicija 1", "Pozicija 2", "Pozicija 3")
 
     Column(
         modifier = Modifier
@@ -66,7 +54,8 @@ fun JobAddSkillsScreen(navController: NavController){
                 SkillListConfirm(
                     text = text,
                     onConfirmClick = {
-                        //prenosi na prošli ekran
+                        jobViewModel.jobPositions.add(JobPosition(text, 1))
+                        navController.popBackStack()
                     }
                 )
             }
@@ -78,5 +67,5 @@ fun JobAddSkillsScreen(navController: NavController){
 @Composable
 fun JobAddSkillsScreenPreview() {
     val navController = rememberNavController()
-    JobAddSkillsScreen(navController)
+    JobAddSkillsScreen(navController, JobViewModel())
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
@@ -1,5 +1,6 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -17,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -29,6 +31,7 @@ import kotlin.text.contains
 fun JobAddSkillsScreen(navController: NavController, jobViewModel: JobViewModel){
     var searchText by remember { mutableStateOf("") }
     val myStrings = listOf("Pozicija 1", "Pozicija 2", "Pozicija 3")
+    val context = LocalContext.current
 
     Column(
         modifier = Modifier
@@ -55,8 +58,11 @@ fun JobAddSkillsScreen(navController: NavController, jobViewModel: JobViewModel)
                 SkillListConfirm(
                     text = text,
                     onConfirmClick = {
-                        jobViewModel.jobPositions.add(JobPosition(text, mutableIntStateOf(1)))
-                        navController.popBackStack()
+                        if (!jobViewModel.jobPositions.any { it.name == text }){
+                            jobViewModel.jobPositions.add(JobPosition(text, mutableIntStateOf(1)))
+                            navController.popBackStack()
+                        }
+                        Toast.makeText(context, "Pozicija već postoji", Toast.LENGTH_SHORT).show()
                     }
                 )
             }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
@@ -1,0 +1,3 @@
+package hr.foi.air.baufind.ui.screens.JobCreateScreen
+
+//ekran za dodavanje uloga koje su potrebne za posao

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
@@ -1,3 +1,19 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+
 //ekran za dodavanje uloga koje su potrebne za posao
+@Composable
+fun JobAddSkillsScreen(navController: NavController){
+
+}
+
+@Preview(showBackground = true)
+@Composable
+fun JobAddSkillsScreenPreview() {
+    val navController = rememberNavController()
+    JobAddSkillsScreen(navController)
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
@@ -52,7 +52,6 @@ fun JobDetailsScreen(navController: NavController){
     var jobDescription by remember { mutableStateOf("") }
     var jobDescriptionError by remember { mutableStateOf("") }
     var allowInvitations by remember { mutableStateOf(false) }
-    val context = LocalContext.current
     var selectedImageUris by remember { mutableStateOf<List<Uri>>(emptyList())}
 
     val launcher = rememberLauncherForActivityResult(
@@ -66,14 +65,6 @@ fun JobDetailsScreen(navController: NavController){
             }
         }
     }
-
-    val mockPictures = listOf(
-        R.drawable.image_icon,
-        R.drawable.image_icon,
-        R.drawable.image_icon,
-        R.drawable.image_icon,
-        R.drawable.image_icon
-    )
 
     fun validateInputs(): Boolean {
         var valid = true
@@ -138,7 +129,6 @@ fun JobDetailsScreen(navController: NavController){
             fontWeight = FontWeight.Bold
         )
         Spacer(modifier = Modifier.height(24.dp))
-        //uzima mock listu slika i prikazuje
         LazyRow {
             items(selectedImageUris){ imageUri ->
                 PictureItem(imageUri = imageUri)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
@@ -1,6 +1,7 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
 import android.widget.Toast
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +11,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -30,6 +33,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.R
+import hr.foi.air.baufind.ui.components.PictureItem
 import hr.foi.air.baufind.ui.components.PrimaryButton
 import hr.foi.air.baufind.ui.components.PrimaryTextField
 
@@ -42,6 +46,14 @@ fun JobDetailsScreen(navController: NavController){
     var jobDescriptionError by remember { mutableStateOf("") }
     var allowInvitations by remember { mutableStateOf(false) }
     val context = LocalContext.current
+
+    val mockPictures = listOf(
+        R.drawable.image_icon,
+        R.drawable.image_icon,
+        R.drawable.image_icon,
+        R.drawable.image_icon,
+        R.drawable.image_icon
+    )
 
     fun validateInputs(): Boolean {
         var valid = true
@@ -99,8 +111,11 @@ fun JobDetailsScreen(navController: NavController){
             fontWeight = FontWeight.Bold
         )
         Spacer(modifier = Modifier.height(24.dp))
-        Row {
-            //tu ce ic slike
+        //uzima mock listu slika i prikazuje
+        LazyRow {
+            itemsIndexed(mockPictures) { index, drawableId ->
+                PictureItem(drawableId = drawableId)
+            }
         }
         Spacer(modifier = Modifier.height(24.dp))
         Text(

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
@@ -1,0 +1,83 @@
+package hr.foi.air.baufind.ui.screens.JobCreateScreen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import hr.foi.air.baufind.ui.components.PrimaryButton
+import hr.foi.air.baufind.ui.components.PrimaryTextField
+
+//ekran za dodavanje naslova, opisa, fotografija i toggle za dopuštanje pozivanja od strane radnika
+@Composable
+fun JobDetailsScreen(navController: NavController){
+    var jobName by remember { mutableStateOf("") }
+    var jobNameError by remember { mutableStateOf("") }
+    var jobDescription by remember { mutableStateOf("") }
+    var jobDescriptionError by remember { mutableStateOf("") }
+    var allowInvitations by remember { mutableStateOf(false) }
+
+    fun validateInputs(): Boolean {
+        var valid = true
+
+        jobNameError =""
+        jobDescriptionError=""
+
+        if (jobName.isBlank()) {
+            jobNameError = "You must enter your email"
+            valid = false
+        }
+        if (jobDescription.isBlank()) {
+            jobDescriptionError = "You must enter your password"
+            valid = false
+        }
+        return valid
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(22.dp)
+    ){
+        PrimaryTextField(
+            value = jobName,
+            onValueChange = { jobName = it },
+            label = "Naslov posla",
+            modifier = Modifier.fillMaxWidth(),
+            isError = jobNameError.isNotEmpty(),
+            errorMessage = jobNameError
+        )
+        PrimaryTextField(
+            value = jobDescription,
+            onValueChange = { jobDescription = it },
+            label = "Opis posla",
+            modifier = Modifier.fillMaxWidth(),
+            isError = jobDescriptionError.isNotEmpty(),
+            errorMessage = jobDescriptionError
+        )
+        PrimaryButton(
+            text = "Učitaj fotografije",
+            maxWidth = true,
+            onClick = {
+                //Ovdje ide logika za učitavanje fotografija
+            }
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun JobDetailsScreenPreview() {
+    val navController = rememberNavController()
+    JobDetailsScreen(navController)
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
@@ -1,6 +1,12 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.provider.MediaStore
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,6 +18,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -46,6 +53,19 @@ fun JobDetailsScreen(navController: NavController){
     var jobDescriptionError by remember { mutableStateOf("") }
     var allowInvitations by remember { mutableStateOf(false) }
     val context = LocalContext.current
+    var selectedImageUris by remember { mutableStateOf<List<Uri>>(emptyList())}
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ){ result ->
+        if(result.resultCode == Activity.RESULT_OK){
+            val data: Intent? = result.data
+            val selectedUri = data?.data
+            if(selectedUri != null){
+                selectedImageUris = selectedImageUris + selectedUri
+            }
+        }
+    }
 
     val mockPictures = listOf(
         R.drawable.image_icon,
@@ -78,6 +98,13 @@ fun JobDetailsScreen(navController: NavController){
             .padding(22.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ){
+        Text(
+            text ="Novi posao",
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            fontSize = 26.sp,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(24.dp))
         PrimaryTextField(
             value = jobName,
             onValueChange = { jobName = it },
@@ -99,8 +126,8 @@ fun JobDetailsScreen(navController: NavController){
             maxWidth = true,
             drawableId = R.drawable.upload_file_icon,
             onClick = {
-                //Ovdje ide logika za učitavanje fotografija
-                Toast.makeText(context, "Učitavanje fotografija", Toast.LENGTH_SHORT).show()
+                val intent = Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+                launcher.launch(intent)
             }
         )
         Spacer(modifier = Modifier.height(24.dp))
@@ -113,8 +140,8 @@ fun JobDetailsScreen(navController: NavController){
         Spacer(modifier = Modifier.height(24.dp))
         //uzima mock listu slika i prikazuje
         LazyRow {
-            itemsIndexed(mockPictures) { index, drawableId ->
-                PictureItem(drawableId = drawableId)
+            items(selectedImageUris){ imageUri ->
+                PictureItem(imageUri = imageUri)
             }
         }
         Spacer(modifier = Modifier.height(24.dp))
@@ -135,7 +162,7 @@ fun JobDetailsScreen(navController: NavController){
             text = "Nastavi",
             onClick = {
                 if (validateInputs()) {
-                    navController.navigate("workerSearch")
+                    navController.navigate("jobPositionsLocationScreen")
                 }
             }
         )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
@@ -44,15 +44,10 @@ import hr.foi.air.baufind.ui.components.PictureItem
 import hr.foi.air.baufind.ui.components.PrimaryButton
 import hr.foi.air.baufind.ui.components.PrimaryTextField
 
-//ekran za dodavanje naslova, opisa, fotografija i toggle za dopuštanje pozivanja od strane radnika
 @Composable
-fun JobDetailsScreen(navController: NavController){
-    var jobName by remember { mutableStateOf("") }
+fun JobDetailsScreen(navController: NavController, jobViewModel: JobViewModel){
     var jobNameError by remember { mutableStateOf("") }
-    var jobDescription by remember { mutableStateOf("") }
     var jobDescriptionError by remember { mutableStateOf("") }
-    var allowInvitations by remember { mutableStateOf(false) }
-    var selectedImageUris by remember { mutableStateOf<List<Uri>>(emptyList())}
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -61,7 +56,7 @@ fun JobDetailsScreen(navController: NavController){
             val data: Intent? = result.data
             val selectedUri = data?.data
             if(selectedUri != null){
-                selectedImageUris = selectedImageUris + selectedUri
+                jobViewModel.selectedImages.add(selectedUri)
             }
         }
     }
@@ -72,11 +67,11 @@ fun JobDetailsScreen(navController: NavController){
         jobNameError =""
         jobDescriptionError=""
 
-        if (jobName.isBlank()) {
+        if (jobViewModel.jobName.value.isBlank()) {
             jobNameError = "Morate unijeti ime posla"
             valid = false
         }
-        if (jobDescription.isBlank()) {
+        if (jobViewModel.jobDescription.value.isBlank()) {
             jobDescriptionError = "Morate unijeti opis posla"
             valid = false
         }
@@ -97,16 +92,16 @@ fun JobDetailsScreen(navController: NavController){
         )
         Spacer(modifier = Modifier.height(24.dp))
         PrimaryTextField(
-            value = jobName,
-            onValueChange = { jobName = it },
+            value = jobViewModel.jobName.value,
+            onValueChange = { jobViewModel.jobName.value = it },
             label = "Naslov posla",
             modifier = Modifier.fillMaxWidth(),
             isError = jobNameError.isNotEmpty(),
             errorMessage = jobNameError
         )
         PrimaryTextField(
-            value = jobDescription,
-            onValueChange = { jobDescription = it },
+            value = jobViewModel.jobDescription.value,
+            onValueChange = { jobViewModel.jobDescription.value = it },
             label = "Opis posla",
             modifier = Modifier.fillMaxWidth(),
             isError = jobDescriptionError.isNotEmpty(),
@@ -130,7 +125,7 @@ fun JobDetailsScreen(navController: NavController){
         )
         Spacer(modifier = Modifier.height(24.dp))
         LazyRow {
-            items(selectedImageUris){ imageUri ->
+            items(jobViewModel.selectedImages){ imageUri ->
                 PictureItem(imageUri = imageUri)
             }
         }
@@ -143,8 +138,8 @@ fun JobDetailsScreen(navController: NavController){
         )
         Spacer(modifier = Modifier.height(24.dp))
         Switch(
-            checked = allowInvitations,
-            onCheckedChange = { allowInvitations = it },
+            checked = jobViewModel.allowInvitations.value,
+            onCheckedChange = { jobViewModel.allowInvitations.value = it },
             modifier = Modifier.align(Alignment.Start)
         )
         Spacer(modifier = Modifier.height(24.dp))
@@ -152,7 +147,6 @@ fun JobDetailsScreen(navController: NavController){
             text = "Nastavi",
             onClick = {
                 if (validateInputs()) {
-                    //moram prenijet unesene podatke
                     navController.navigate("jobPositionsLocationScreen")
                 }
             }
@@ -164,5 +158,5 @@ fun JobDetailsScreen(navController: NavController){
 @Composable
 fun JobDetailsScreenPreview() {
     val navController = rememberNavController()
-    JobDetailsScreen(navController)
+    JobDetailsScreen(navController, JobViewModel())
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
@@ -73,11 +73,11 @@ fun JobDetailsScreen(navController: NavController){
         jobDescriptionError=""
 
         if (jobName.isBlank()) {
-            jobNameError = "You must enter your email"
+            jobNameError = "Morate unijeti ime posla"
             valid = false
         }
         if (jobDescription.isBlank()) {
-            jobDescriptionError = "You must enter your password"
+            jobDescriptionError = "Morate unijeti opis posla"
             valid = false
         }
         return valid
@@ -152,6 +152,7 @@ fun JobDetailsScreen(navController: NavController){
             text = "Nastavi",
             onClick = {
                 if (validateInputs()) {
+                    //moram prenijet unesene podatke
                     navController.navigate("jobPositionsLocationScreen")
                 }
             }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
@@ -1,20 +1,35 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import hr.foi.air.baufind.R
 import hr.foi.air.baufind.ui.components.PrimaryButton
 import hr.foi.air.baufind.ui.components.PrimaryTextField
 
@@ -26,6 +41,7 @@ fun JobDetailsScreen(navController: NavController){
     var jobDescription by remember { mutableStateOf("") }
     var jobDescriptionError by remember { mutableStateOf("") }
     var allowInvitations by remember { mutableStateOf(false) }
+    val context = LocalContext.current
 
     fun validateInputs(): Boolean {
         var valid = true
@@ -47,7 +63,8 @@ fun JobDetailsScreen(navController: NavController){
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(22.dp)
+            .padding(22.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ){
         PrimaryTextField(
             value = jobName,
@@ -68,8 +85,43 @@ fun JobDetailsScreen(navController: NavController){
         PrimaryButton(
             text = "Učitaj fotografije",
             maxWidth = true,
+            drawableId = R.drawable.upload_file_icon,
             onClick = {
                 //Ovdje ide logika za učitavanje fotografija
+                Toast.makeText(context, "Učitavanje fotografija", Toast.LENGTH_SHORT).show()
+            }
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = "Fotografije",
+            modifier = Modifier.align(Alignment.Start),
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Row {
+            //tu ce ic slike
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Text(
+            text = "Dopusti pozivanja od strane radnika",
+            modifier = Modifier.align(Alignment.Start),
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Switch(
+            checked = allowInvitations,
+            onCheckedChange = { allowInvitations = it },
+            modifier = Modifier.align(Alignment.Start)
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        PrimaryButton(
+            text = "Nastavi",
+            onClick = {
+                if (validateInputs()) {
+                    navController.navigate("workerSearch")
+                }
             }
         )
     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -2,12 +2,19 @@ package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -20,14 +27,44 @@ import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.R
 import hr.foi.air.baufind.ui.components.PositionAndNumber
 import hr.foi.air.baufind.ui.components.PrimaryButton
+import hr.foi.air.baufind.ui.components.PrimaryTextField
 
 @Composable
 fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobViewModel){
 
+    var latError by remember { mutableStateOf("") }
+    var longError by remember { mutableStateOf("") }
+    var context = LocalContext.current
+
+    var latText by remember { mutableStateOf(jobViewModel.lat.doubleValue.toString()) }
+    var longText by remember { mutableStateOf(jobViewModel.long.doubleValue.toString()) }
+
     fun validateInputs(): Boolean {
         var valid = true
 
+        latError = ""
+        longError = ""
+
+        if (latText.isEmpty() || latText.toDoubleOrNull() == null) {
+            latError = "Morate unijeti validan lat"
+            valid = false
+        }
+        if (longText.isEmpty() || longText.toDoubleOrNull() == null) {
+            longError = "Morate unijeti validan long"
+            valid = false
+        }
+        if (jobViewModel.jobPositions.isEmpty()) {
+            Toast.makeText(context, "Morate unijeti bar jednu poziciju", Toast.LENGTH_SHORT).show()
+            valid = false
+        }
         return valid
+    }
+
+    fun updateCoordinates() {
+        val latValue = latText.toDoubleOrNull() ?: 0.0
+        val longValue = longText.toDoubleOrNull() ?: 0.0
+        jobViewModel.lat.doubleValue = latValue
+        jobViewModel.long.doubleValue = longValue
     }
 
     Column(
@@ -42,6 +79,7 @@ fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobVi
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold
         )
+        Spacer(modifier = Modifier.height(24.dp))
         LazyColumn {
             items(jobViewModel.jobPositions) { position ->
                 PositionAndNumber(
@@ -58,22 +96,44 @@ fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobVi
                 navController.navigate("jobAddSkillsScreen")
             }
         )
+        Spacer(modifier = Modifier.height(24.dp))
         Text(
             text = "Lokacija posla",
             modifier = Modifier.align(Alignment.Start),
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold
         )
+        Spacer(modifier = Modifier.height(24.dp))
+        PrimaryTextField(
+            value = latText,
+            onValueChange = { latText = it },
+            label = "Lat",
+            modifier = Modifier.fillMaxWidth(),
+            isError = latError.isNotEmpty(),
+            errorMessage = latError
+        )
+        PrimaryTextField(
+            value = longText,
+            onValueChange = { longText = it },
+            label = "Lng",
+            modifier = Modifier.fillMaxWidth(),
+            isError = longError.isNotEmpty(),
+            errorMessage = longError
+        )
+        Spacer(modifier = Modifier.height(24.dp))
         PrimaryButton(
             text = "Postavi oglas",
             onClick = {
                 if (validateInputs()) {
+                    updateCoordinates()
                     val jobDetails = mapOf(
                         "name" to jobViewModel.jobName.value,
                         "description" to jobViewModel.jobDescription.value,
                         "allowInvitations" to jobViewModel.allowInvitations.value,
                         "positions" to jobViewModel.jobPositions.map { "${it.name}: ${it.count}" },
-                        "images" to jobViewModel.selectedImages
+                        "images" to jobViewModel.selectedImages,
+                        "lat" to jobViewModel.lat.doubleValue,
+                        "long" to jobViewModel.long.doubleValue
                     )
                     println(jobDetails)
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -4,6 +4,8 @@ import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -19,10 +21,8 @@ import hr.foi.air.baufind.R
 import hr.foi.air.baufind.ui.components.PositionAndNumber
 import hr.foi.air.baufind.ui.components.PrimaryButton
 
-//ekran sa pozicijama koje su potrebne za posao i lokacijom posla
 @Composable
-fun JobPositionsLocationScreen(navController: NavController){
-    val context = LocalContext.current
+fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobViewModel){
 
     fun validateInputs(): Boolean {
         var valid = true
@@ -42,14 +42,15 @@ fun JobPositionsLocationScreen(navController: NavController){
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold
         )
-        /*
-        PositionAndNumber(
-            text = "Zidar",
-            onCountChange = { count ->
-                Toast.makeText(context, "Count changed to $count", Toast.LENGTH_SHORT).show()
+        LazyColumn {
+            items(jobViewModel.jobPositions) { position ->
+                PositionAndNumber(
+                    text = position.name,
+                    initialCount = position.count,
+                    onCountChange = { newCount -> position.count = newCount }
+                )
             }
-        )
-         */
+        }
         PrimaryButton(
             drawableId = R.drawable.add_person_icon,
             text = "Dodaj poziciju",
@@ -67,7 +68,14 @@ fun JobPositionsLocationScreen(navController: NavController){
             text = "Postavi oglas",
             onClick = {
                 if (validateInputs()) {
-                    //posta se posao i vraca ga negdje
+                    val jobDetails = mapOf(
+                        "name" to jobViewModel.jobName.value,
+                        "description" to jobViewModel.jobDescription.value,
+                        "allowInvitations" to jobViewModel.allowInvitations.value,
+                        "positions" to jobViewModel.jobPositions.map { "${it.name}: ${it.count}" },
+                        "images" to jobViewModel.selectedImages
+                    )
+                    println(jobDetails)
                 }
             }
         )
@@ -78,5 +86,5 @@ fun JobPositionsLocationScreen(navController: NavController){
 @Composable
 fun JobPositionsLocationScreenPreview() {
     val navController = rememberNavController()
-    JobPositionsLocationScreen(navController)
+    JobPositionsLocationScreen(navController, JobViewModel())
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 
 //ekran sa pozicijama koje su potrebne za posao i lokacijom posla
 @Composable
@@ -36,4 +38,11 @@ fun JobPositionsLocationScreen(navController: NavController){
             fontWeight = FontWeight.Bold
         )
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun JobPositionsLocationScreenPreview() {
+    val navController = rememberNavController()
+    JobPositionsLocationScreen(navController)
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -46,8 +46,8 @@ fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobVi
             items(jobViewModel.jobPositions) { position ->
                 PositionAndNumber(
                     text = position.name,
-                    initialCount = position.count,
-                    onCountChange = { newCount -> position.count = newCount }
+                    count = position.count.value,
+                    onCountChange = { newCount -> position.count.value = newCount }
                 )
             }
         }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -1,5 +1,6 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -7,17 +8,27 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import hr.foi.air.baufind.R
+import hr.foi.air.baufind.ui.components.PositionAndNumber
+import hr.foi.air.baufind.ui.components.PrimaryButton
 
 //ekran sa pozicijama koje su potrebne za posao i lokacijom posla
 @Composable
 fun JobPositionsLocationScreen(navController: NavController){
+    val context = LocalContext.current
 
+    fun validateInputs(): Boolean {
+        var valid = true
+
+        return valid
+    }
 
     Column(
         modifier = Modifier
@@ -31,11 +42,34 @@ fun JobPositionsLocationScreen(navController: NavController){
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold
         )
+        /*
+        PositionAndNumber(
+            text = "Zidar",
+            onCountChange = { count ->
+                Toast.makeText(context, "Count changed to $count", Toast.LENGTH_SHORT).show()
+            }
+        )
+         */
+        PrimaryButton(
+            drawableId = R.drawable.add_person_icon,
+            text = "Dodaj poziciju",
+            onClick = {
+                //navController.navigate("jobAddSkillsScreen")
+            }
+        )
         Text(
             text = "Lokacija posla",
             modifier = Modifier.align(Alignment.Start),
             fontSize = 20.sp,
             fontWeight = FontWeight.Bold
+        )
+        PrimaryButton(
+            text = "Postavi oglas",
+            onClick = {
+                if (validateInputs()) {
+                    //navController.navigate("jobPositionsLocationScreen")
+                }
+            }
         )
     }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -1,0 +1,3 @@
+package hr.foi.air.baufind.ui.screens.JobCreateScreen
+
+//ekran sa pozicijama koje su potrebne za posao i lokacijom posla

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -36,8 +36,8 @@ fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobVi
     var longError by remember { mutableStateOf("") }
     var context = LocalContext.current
 
-    var latText by remember { mutableStateOf(jobViewModel.lat.doubleValue.toString()) }
-    var longText by remember { mutableStateOf(jobViewModel.long.doubleValue.toString()) }
+    var latText by remember { mutableStateOf("") }
+    var longText by remember { mutableStateOf("") }
 
     fun validateInputs(): Boolean {
         var valid = true

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -1,6 +1,7 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
 import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -80,15 +81,19 @@ fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobVi
             fontWeight = FontWeight.Bold
         )
         Spacer(modifier = Modifier.height(24.dp))
-        LazyColumn {
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
             items(jobViewModel.jobPositions) { position ->
                 PositionAndNumber(
                     text = position.name,
                     count = position.count.value,
-                    onCountChange = { newCount -> position.count.value = newCount }
+                    onCountChange = { newCount -> position.count.value = newCount },
+                    onDelete = { jobViewModel.jobPositions.remove(position) }
                 )
             }
         }
+        Spacer(modifier = Modifier.height(24.dp))
         PrimaryButton(
             drawableId = R.drawable.add_person_icon,
             text = "Dodaj poziciju",

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -54,7 +54,7 @@ fun JobPositionsLocationScreen(navController: NavController){
             drawableId = R.drawable.add_person_icon,
             text = "Dodaj poziciju",
             onClick = {
-                //navController.navigate("jobAddSkillsScreen")
+                navController.navigate("jobAddSkillsScreen")
             }
         )
         Text(
@@ -67,7 +67,7 @@ fun JobPositionsLocationScreen(navController: NavController){
             text = "Postavi oglas",
             onClick = {
                 if (validateInputs()) {
-                    //navController.navigate("jobPositionsLocationScreen")
+                    //posta se posao i vraca ga negdje
                 }
             }
         )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -1,3 +1,39 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+
 //ekran sa pozicijama koje su potrebne za posao i lokacijom posla
+@Composable
+fun JobPositionsLocationScreen(navController: NavController){
+
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(22.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ){
+        Text(
+            text = "Tražene pozicije",
+            modifier = Modifier.align(Alignment.Start),
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = "Lokacija posla",
+            modifier = Modifier.align(Alignment.Start),
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobViewModel.kt
@@ -1,0 +1,19 @@
+package hr.foi.air.baufind.ui.screens.JobCreateScreen
+
+import android.net.Uri
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+
+data class JobPosition(
+    val name: String,
+    var count: Int
+)
+
+class JobViewModel : ViewModel(){
+    val jobName = mutableStateOf("")
+    val jobDescription = mutableStateOf("")
+    val allowInvitations = mutableStateOf(false)
+    val selectedImages = mutableStateListOf<Uri>()
+    val jobPositions = mutableStateListOf<JobPosition>()
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobViewModel.kt
@@ -2,6 +2,7 @@ package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
 import android.net.Uri
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -18,4 +19,6 @@ class JobViewModel : ViewModel(){
     val allowInvitations = mutableStateOf(false)
     val selectedImages = mutableStateListOf<Uri>()
     val jobPositions = mutableStateListOf<JobPosition>()
+    val lat = mutableDoubleStateOf(0.0)
+    val long = mutableDoubleStateOf(0.0)
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobViewModel.kt
@@ -1,13 +1,15 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
 import android.net.Uri
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 
 data class JobPosition(
     val name: String,
-    var count: Int
+    var count: MutableState<Int> = mutableIntStateOf(0)
 )
 
 class JobViewModel : ViewModel(){

--- a/Software/Frontend/app/src/main/res/drawable/add_person_icon.xml
+++ b/Software/Frontend/app/src/main/res/drawable/add_person_icon.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M15,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM6,10L6,7L4,7v3L1,10v2h3v3h2v-3h3v-2L6,10zM15,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+    
+</vector>

--- a/Software/Frontend/app/src/main/res/drawable/image_icon.xml
+++ b/Software/Frontend/app/src/main/res/drawable/image_icon.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z"/>
+    
+</vector>

--- a/Software/Frontend/app/src/main/res/drawable/upload_file_icon.xml
+++ b/Software/Frontend/app/src/main/res/drawable/upload_file_icon.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#FFFFFF" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M14,2L6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6zM18,20L6,20L6,4h7v5h5v11zM8,15.01l1.41,1.41L11,14.84L11,19h2v-4.16l1.59,1.59L16,15.01 12.01,11z"/>
+    
+</vector>


### PR DESCRIPTION
Napravljeni ekrani za kreiranje novog posla od strane korisnika.
Implementirana su 3 ekrana i jedan ViewModel.
## Prvi ekran
Dodaje se naziv posla i opis posla što su obavezna polja, uploadaju se slike sa mobitela i prikazuju i može se uključiti ili isključiti dopuštenje da radnici mogu pozivati druge radnike na posao tj obican bool. Slike imaju horizontalni scroll.

![image](https://github.com/user-attachments/assets/5244443f-6336-4a24-b25f-c4f464449fdd)

## Drugi ekran
Tu se mogu dodavati pozicije koje trebamo za posao klikom na gumb koji će nas odvesti na treći ekran. Nakon što dodamo poziciju možemo staviti koliko ljudi trebamo na toj poziciji i možemo obrisati poziciju. Također sam privremeno stavio unos lat i lng jer se moramo dogovoriti još za modularnost mapa. Imam validaciju da mora bit barem jedna dodana pozicija i da lat i lng moraju biti ispravni. Nakon pritiska "Postavi oglas" se svi podatci samo ispisuju u log.
![image](https://github.com/user-attachments/assets/525a233c-f832-453b-a8d9-5be3336e7abb)

@dmatijani Mislim da bi sve trebalo biti u skladu s bazom, jedino moram URI slike pretvorit u base64 ili nešto prije slanja na API al to se moramo dogovoriti
![image](https://github.com/user-attachments/assets/e227aec6-64ec-4527-adc9-dbaec1009c11)



## Treći ekran
Tu se dodaju pozicije koje želimo na poslu, ima implementiran i search.
![image](https://github.com/user-attachments/assets/9f0697a8-c0f4-42da-844a-3d80976d39ce)


## Viewmodel
Napravljen je viewmodel kako bi se prenosio state tj kako bi se podatci mogli prenositi od ekrana do ekrana. Jedan zajednički viewmodel se daje svim ekranima u MainActivity.kt tako da dijele jedan view state kojem svi ekrani onda pristupaju.
![image](https://github.com/user-attachments/assets/a38c5cfa-6d9c-4dec-a345-8777a510ebf5)