### PR TITLE
Bauf 11 kao poslodavac elim pretra ivati dostupne radnike uz pomo filtera kako bih mogao prona i odgovaraju eg kandidata

### DIFF
--- a/Software/Backend/BusinessLogicLayer/AppLogic/Workers/GetWorkers/GetWorkersBody.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Workers/GetWorkers/GetWorkersBody.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+///summary
+/// Podaci koji se šalju u tijelu, naziv vještine
+///summary
+
+namespace BusinessLogicLayer.AppLogic.Workers.GetWorkers {
+    public record GetWorkersBody {
+        public string Title { get; set; }
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Workers/GetWorkers/GetWorkersResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Workers/GetWorkers/GetWorkersResponse.cs
@@ -1,0 +1,18 @@
+﻿using DataAccessLayer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Odgovor koji se šalje preko API zahtjeva za dobivanje svih radnika po vještini
+/// </summary>
+
+namespace BusinessLogicLayer.AppLogic.Workers.GetWorkers {
+
+    public record GetWorkersResponse {
+        public List<WorkerRecord> workerRecords { get; set; } = new List<WorkerRecord>();
+        public string? Error { get; set; } = string.Empty;
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Workers/IWorkersService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Workers/IWorkersService.cs
@@ -1,0 +1,12 @@
+﻿using BusinessLogicLayer.AppLogic.Workers.GetWorkers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BusinessLogicLayer.AppLogic.Workers {
+    public interface IWorkersService {
+        public GetWorkersResponse GetWorkers(string skill);
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Workers/WorkerRecord.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Workers/WorkerRecord.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 namespace DataAccessLayer.Models {
-    public record WorkerModel {
+    public record WorkerRecord {
         public int Id { get; set; }
         public string Name { get; set; }
         public string Address { get; set; }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/WorkersService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/WorkersService.cs
@@ -1,0 +1,47 @@
+﻿using BusinessLogicLayer.AppLogic.Users.GetAllUsers;
+using BusinessLogicLayer.AppLogic.Users;
+using BusinessLogicLayer.AppLogic.Workers;
+using BusinessLogicLayer.AppLogic.Workers.GetWorkers;
+using DataAccessLayer.AppLogic;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DataAccessLayer.Models;
+
+namespace BusinessLogicLayer.Infrastructure {
+    public class WorkersService : IWorkersService {
+
+        private IWorkerRepository _workerRepository;
+
+        public WorkersService(IWorkerRepository workerRepository)
+        {
+            this._workerRepository = workerRepository;   
+        }
+        public GetWorkersResponse GetWorkers(string skill) 
+        {
+            var query = _workerRepository.GetWorkers(skill);
+
+            if (query == null || !query.Any()) {
+                return new GetWorkersResponse() {
+                    Error = "U bazi nema korisnika!"
+                };
+            }
+
+            var workers = query.Select(x => new WorkerRecord() {
+                Id = x.Id,
+                Name = x.Name,
+                Address = x.Address,
+                NumOfJobs = x.NumOfJobs,
+                Skills = x.Skills,
+                AvgRating = x.AvgRating
+            }).ToList();
+
+            return new GetWorkersResponse() {
+                workerRecords = workers
+            };
+
+        }
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/ServiceCollectionExtensions.cs
+++ b/Software/Backend/BusinessLogicLayer/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using BusinessLogicLayer.AppLogic;
 using BusinessLogicLayer.AppLogic.Users;
+using BusinessLogicLayer.AppLogic.Workers;
 using BusinessLogicLayer.Infrastructure;
 using DataAccessLayer;
 using DataAccessLayer.AppLogic;
@@ -30,10 +31,11 @@ public static class ServiceCollectionExtensions
 
         // Repozitoriji
         services.AddScoped<IUserRepository, UserRepository>();
-
+        services.AddScoped<IWorkerRepository,WorkerRepository>();
         // Servisi
         services.AddScoped<IJwtService, JwtService>();
         services.AddScoped<IUserService, UserService>();
+        services.AddScoped<IWorkersService,WorkersService>();   
 
         return services;
     }

--- a/Software/Backend/DataAccessLayer/AppLogic/IWorkerRepository.cs
+++ b/Software/Backend/DataAccessLayer/AppLogic/IWorkerRepository.cs
@@ -1,0 +1,12 @@
+﻿using DataAccessLayer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccessLayer.AppLogic {
+    public interface IWorkerRepository {
+        public List<WorkerModel>? GetWorkers(string skill);
+    }
+}

--- a/Software/Backend/DataAccessLayer/Infrastructure/WorkerRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/WorkerRepository.cs
@@ -26,7 +26,7 @@ namespace DataAccessLayer.Infrastructure {
          public List<WorkerModel>? GetWorkers(string skill) 
         {
 
-            string query = $"SELECT \r\n    u.id, \r\n    u.name, \r\n    u.address, \r\n    COUNT(j.id) AS numOfJobs, \r\n    s.title AS skills,  \r\n    AVG(wr.rating) AS avgRating \r\nFROM \r\n    app_user u\r\nLEFT JOIN \r\n    working w ON u.id = w.worker_id\r\nLEFT JOIN \r\n    job j ON w.job_id = j.id\r\nLEFT JOIN \r\n    worker_review wr ON w.id = wr.working_id\r\nLEFT JOIN \r\n    user_skill us ON u.id = us.user_id\r\nLEFT JOIN \r\n    skill s ON us.skill_id = s.id\r\nWHERE \r\n\ts.title = '{skill}'\r\nGROUP BY \r\n    u.id, u.name, u.address, s.title;";
+            string query = $"SELECT \r\n    u.id, \r\n    u.name, \r\n    u.address, \r\n    COUNT(j.id) AS numOfJobs, \r\n    s.title AS skills,  \r\n    COALESCE(CAST(AVG(CAST(wr.rating AS DECIMAL(3, 2))) AS DECIMAL(5, 2)), 0.00) AS avgRating\r\nFROM \r\n    app_user u\r\nLEFT JOIN \r\n    working w ON u.id = w.worker_id\r\nLEFT JOIN \r\n    job j ON w.job_id = j.id\r\nLEFT JOIN \r\n    worker_review wr ON w.id = wr.working_id\r\nLEFT JOIN \r\n    user_skill us ON u.id = us.user_id\r\nLEFT JOIN \r\n    skill s ON us.skill_id = s.id\r\nWHERE \r\n    s.title = '{skill}'\r\nGROUP BY \r\n    u.id, u.name, u.address, s.title;";
             using (var reader = dB.ExecuteReader(query)) {
                 var result = new List<WorkerModel>();
                 while (reader.Read()) {
@@ -44,7 +44,7 @@ namespace DataAccessLayer.Infrastructure {
                 Address = (string)reader["address"],
                 NumOfJobs = (int)reader["numOfJobs"],
                 Skills = (string)reader["skills"],
-                AvgRating = (double)reader["avgRating"]
+                AvgRating = reader.IsDBNull(reader.GetOrdinal("avgRating")) ? 0m : (decimal)reader["avgRating"]
 
             };
         }

--- a/Software/Backend/DataAccessLayer/Infrastructure/WorkerRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/WorkerRepository.cs
@@ -1,0 +1,53 @@
+﻿using DataAccessLayer.AppLogic;
+using DataAccessLayer.Models;
+using Microsoft.Data.SqlClient;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccessLayer.Infrastructure {
+
+    /// <summary>
+    /// Repozitorij za dohvaćanje radnika prema vještini za popunavanje poslova.
+    /// </summary>
+    public class WorkerRepository : IWorkerRepository {
+
+        private readonly DB dB;
+        public WorkerRepository(DB Db)
+        {
+            this.dB = Db;
+        }
+        /// <summary>
+        /// Implementacija dohvaćanja radnika prema vještini
+        /// </summary>
+        /// Returns WorkerModel - Radnik koji zadovoljava određenu vještinu i njegove informacije o bivšim poslovima i prosječnoj ocjeni
+         public List<WorkerModel>? GetWorkers(string skill) 
+        {
+
+            string query = $"SELECT \r\n    u.id, \r\n    u.name, \r\n    u.address, \r\n    COUNT(j.id) AS numOfJobs, \r\n    s.title AS skills,  \r\n    AVG(wr.rating) AS avgRating \r\nFROM \r\n    app_user u\r\nLEFT JOIN \r\n    working w ON u.id = w.worker_id\r\nLEFT JOIN \r\n    job j ON w.job_id = j.id\r\nLEFT JOIN \r\n    worker_review wr ON w.id = wr.working_id\r\nLEFT JOIN \r\n    user_skill us ON u.id = us.user_id\r\nLEFT JOIN \r\n    skill s ON us.skill_id = s.id\r\nWHERE \r\n\ts.title = '{skill}'\r\nGROUP BY \r\n    u.id, u.name, u.address, s.title;";
+            using (var reader = dB.ExecuteReader(query)) {
+                var result = new List<WorkerModel>();
+                while (reader.Read()) {
+                    result.Add(WorkerModelFromReader(reader));
+                }
+
+                return result;
+            }
+
+        }
+        private WorkerModel WorkerModelFromReader(SqlDataReader reader) {
+            return new WorkerModel {
+                Id = (int)reader["id"],
+                Name = (string)reader["name"],
+                Address = (string)reader["address"],
+                NumOfJobs = (int)reader["numOfJobs"],
+                Skills = (string)reader["skills"],
+                AvgRating = (double)reader["avgRating"]
+
+            };
+        }
+
+    }
+}

--- a/Software/Backend/DataAccessLayer/Models/WorkerModel.cs
+++ b/Software/Backend/DataAccessLayer/Models/WorkerModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccessLayer.Models {
+    public record WorkerModel {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Address { get; set; }
+        public int NumOfJobs { get; set; }
+        public string Skills { get; set; }
+        public double AvgRating { get; set; }
+    }
+}

--- a/Software/Backend/WebApi/Controllers/WorkersController.cs
+++ b/Software/Backend/WebApi/Controllers/WorkersController.cs
@@ -1,9 +1,30 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using BusinessLogicLayer.AppLogic.Workers;
+using BusinessLogicLayer.AppLogic.Workers.GetWorkers;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 
 namespace WebApi.Controllers {
-    [Route("api/[controller]")]
+    [Route("workers")]
     [ApiController]
     public class WorkersController : ControllerBase {
+
+        private readonly IWorkersService _workersService;
+        public WorkersController(IWorkersService workersService)
+        {
+            this._workersService = workersService;
+        }
+        // GET: /workers/{skill}
+        [HttpGet("{skill}")]
+        [Authorize]
+        public ActionResult<GetWorkersResponse> GetWorkers(string skill)
+        {
+            var workers = _workersService.GetWorkers(skill);
+            if (workers.workerRecords == null || !workers.workerRecords.Any())
+            {
+                return NotFound(workers);
+            }
+            return workers;
+        }
     }
 }

--- a/Software/Backend/WebApi/Controllers/WorkersController.cs
+++ b/Software/Backend/WebApi/Controllers/WorkersController.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.Controllers {
+    [Route("api/[controller]")]
+    [ApiController]
+    public class WorkersController : ControllerBase {
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : ComponentActivity() {
                         ) {
                             composable("login") { LoginScreen(navController, this@MainActivity, tokenProvider) }
                             composable("registration") { RegistrationScreen(navController, tokenProvider) }
-                            composable("workersSearchScreen") { WorkerSearchScreen(navController) }
+                            composable("workersSearchScreen") { WorkerSearchScreen(navController,tokenProvider) }
                         }
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : ComponentActivity() {
                         ) {
                             composable("login") { LoginScreen(navController, this@MainActivity, tokenProvider) }
                             composable("registration") { RegistrationScreen(navController, tokenProvider) }
-                            composable("workersSearchScreen") { WorkerSearchScreen(navController,tokenProvider) }
+                            composable("workersSearchScreen") { WorkerSearchScreen(navController,tokenProvider,"") }
                         }
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -57,7 +57,7 @@ class MainActivity : ComponentActivity() {
                         ) {
                             composable("login") { LoginScreen(navController, this@MainActivity, tokenProvider) }
                             composable("registration") { RegistrationScreen(navController, tokenProvider) }
-                            composable("workersSearchScreen") { WorkerSearchScreen(navController,tokenProvider,"") }
+                            composable("workersSearchScreen") { WorkerSearchScreen(navController,tokenProvider,"Vodoinstalater") }
                         }
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
@@ -17,10 +17,14 @@ object WorkerMock {
 
 
     val workers = listOf(
-        Worker(1, "Ivan", "Horvat", "Zagreb", 5, listOf("Vodoinstaler", "Keramičar"), "Full-time", 40000.0, "ivan@email.com",5),
-        Worker(2, "Ana", "Kovač", "Split", 3, listOf("Keramičar", "Električar"), "Part-time", 30000.0, "ana@email.com",2),
-        Worker(3, "Marko", "Novak", "Osijek", 10, listOf("Vodoinstaler", "Keramičar", "Instalater"), "Freelance", 45000.0, null,10),
-        Worker(4, "Luka", "Ivić", "Zadar", 8, listOf("Keramičar", "Majstor"), "Full-time", 35000.0, "luka@email.com",7)
+        Worker(1, "Ivan", "Horvat", "Zagrebačka", 5, listOf("Vodoinstaler", "Keramičar"), "Full-time", 40000.0, "ivan@email.com",5),
+        Worker(2, "Ana", "Kovač", "Splitsko-dalmatinska", 3, listOf("Keramičar", "Električar"), "Part-time", 30000.0, "ana@email.com",2),
+        Worker(3, "Marko", "Novak", "Međimurska", 10, listOf("Vodoinstaler", "Keramičar", "Instalater"), "Freelance", 45000.0, null,10),
+        Worker(1, "Ivan", "Horvat", "Grad Zagreb", 5, listOf("Vodoinstaler", "Keramičar"), "Full-time", 40000.0, "ivan@email.com",5),
+        Worker(2, "Ana", "Kovač", "Ličko-senjska", 3, listOf("Keramičar", "Električar"), "Part-time", 30000.0, "ana@email.com",2),
+        Worker(3, "Marko", "Novak", "Ličko-senjska", 10, listOf("Vodoinstaler", "Keramičar", "Instalater"), "Freelance", 45000.0, null,10),
+        Worker(4, "Luka", "Ivić", "Zadarska", 8, listOf("Keramičar", "Majstor"), "Full-time", 35000.0, "luka@email.com",7),
+        Worker(4, "Kulen", "Ivić", "Zadarska", 10, listOf("Keramičar", "Majstor"), "Full-time", 35000.0, "luka@email.com",7)
     )
 
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
@@ -1,30 +1,63 @@
-package hr.foi.air.baufind.mock.WorkerSearchMock
+import hr.foi.air.baufind.ws.model.Worker
+import java.time.format.DateTimeFormatter
 
 object WorkerMock {
 
-    data class Worker(
-        val id: Int,
-        val firstName: String,
-        val lastName: String,
-        val location: String,
-        val numOfJobs: Int,
-        val skills: List<String>,
-        val availability: String,
-        val expectedSalary: Double,
-        val contactInfo: String?,
-        val rating: Int
-    )
-
-
     val workers = listOf(
-        Worker(1, "Ivan", "Horvat", "Zagrebačka", 5, listOf("Vodoinstaler", "Keramičar"), "Full-time", 40000.0, "ivan@email.com",5),
-        Worker(2, "Ana", "Kovač", "Splitsko-dalmatinska", 3, listOf("Keramičar", "Električar"), "Part-time", 30000.0, "ana@email.com",2),
-        Worker(3, "Marko", "Novak", "Međimurska", 10, listOf("Vodoinstaler", "Keramičar", "Instalater"), "Freelance", 45000.0, null,10),
-        Worker(1, "Ivan", "Horvat", "Grad Zagreb", 5, listOf("Vodoinstaler", "Keramičar"), "Full-time", 40000.0, "ivan@email.com",5),
-        Worker(2, "Ana", "Kovač", "Ličko-senjska", 3, listOf("Keramičar", "Električar"), "Part-time", 30000.0, "ana@email.com",2),
-        Worker(3, "Marko", "Novak", "Ličko-senjska", 10, listOf("Vodoinstaler", "Keramičar", "Instalater"), "Freelance", 45000.0, null,10),
-        Worker(4, "Luka", "Ivić", "Zadarska", 8, listOf("Keramičar", "Majstor"), "Full-time", 35000.0, "luka@email.com",7),
-        Worker(4, "Kulen", "Ivić", "Zadarska", 10, listOf("Keramičar", "Majstor"), "Full-time", 35000.0, "luka@email.com",7)
+        Worker(
+            id = 1,
+            name = "Ivan Horvat",
+            email = "ivan@email.com",
+            phone = "099-123-4567",
+            address = "Zagrebačka",
+            numOfJobs = 5,
+            skills = listOf("Vodoinstaler", "Keramičar"),
+            availability = "Full-time",
+            avgRating = 4.5
+        ),
+        Worker(
+            id = 2,
+            name = "Ana Kovač",
+            email = "ana@email.com",
+            phone = "098-765-4321",
+            address = "Splitsko-dalmatinska",
+            numOfJobs = 3,
+            skills = listOf("Keramičar", "Električar"),
+            availability = "Part-time",
+            avgRating = 4.0
+        ),
+        Worker(
+            id = 3,
+            name = "Marko Novak",
+            email = "marko@email.com",
+            phone = "097-654-3210",
+            address = "Međimurska",
+            numOfJobs = 10,
+            skills = listOf("Vodoinstaler", "Keramičar", "Instalater"),
+            availability = "Freelance",
+            avgRating = 4.8
+        ),
+        Worker(
+            id = 4,
+            name = "Luka Ivić",
+            email = "luka@email.com",
+            phone = "095-987-6543",
+            address = "Zadarska",
+            numOfJobs = 8,
+            skills = listOf("Keramičar", "Majstor"),
+            availability = "Full-time",
+            avgRating = 4.7
+        ),
+        Worker(
+            id = 5,
+            name = "Kulen Ivić",
+            email = "kulen@email.com",
+            phone = "095-555-6543",
+            address = "Ličko-senjska",
+            numOfJobs = 7,
+            skills = listOf("Majstor"),
+            availability = "Full-time",
+            avgRating = 4.6
+        )
     )
-
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
@@ -6,56 +6,41 @@ object WorkerMock {
         Worker(
             id = 1,
             name = "Ivan Horvat",
-            email = "ivan@email.com",
-            phone = "099-123-4567",
             address = "Zagrebačka",
             numOfJobs = 5,
-            skills = listOf("Vodoinstaler", "Keramičar"),
-            availability = "Full-time",
+            skills = "Vodoinstaler",
             avgRating = 4.5
         ),
         Worker(
             id = 2,
             name = "Ana Kovač",
-            email = "ana@email.com",
-            phone = "098-765-4321",
             address = "Splitsko-dalmatinska",
             numOfJobs = 3,
-            skills = listOf("Keramičar", "Električar"),
-            availability = "Part-time",
+            skills = "Keramičar",
             avgRating = 4.0
         ),
         Worker(
             id = 3,
             name = "Marko Novak",
-            email = "marko@email.com",
-            phone = "097-654-3210",
             address = "Međimurska",
             numOfJobs = 10,
-            skills = listOf("Vodoinstaler", "Keramičar", "Instalater"),
-            availability = "Freelance",
+            skills =  "Keramičar",
             avgRating = 4.8
         ),
         Worker(
             id = 4,
             name = "Luka Ivić",
-            email = "luka@email.com",
-            phone = "095-987-6543",
             address = "Zadarska",
             numOfJobs = 8,
-            skills = listOf("Keramičar", "Majstor"),
-            availability = "Full-time",
+            skills = "Keramičar",
             avgRating = 4.7
         ),
         Worker(
             id = 5,
             name = "Kulen Ivić",
-            email = "kulen@email.com",
-            phone = "095-555-6543",
             address = "Ličko-senjska",
             numOfJobs = 7,
-            skills = listOf("Majstor"),
-            availability = "Full-time",
+            skills = "Majstor",
             avgRating = 4.6
         )
     )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerMock.kt
@@ -1,5 +1,4 @@
 import hr.foi.air.baufind.ws.model.Worker
-import java.time.format.DateTimeFormatter
 
 object WorkerMock {
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerTitleMock.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/mock/WorkerSearchMock/WorkerTitleMock.kt
@@ -1,0 +1,7 @@
+package hr.foi.air.baufind.mock.WorkerSearchMock
+
+import hr.foi.air.baufind.ws.request.WorkersSkillBody
+
+object WorkerTitleMock {
+    val workersSkillBody: WorkersSkillBody = WorkersSkillBody("Vodoinstalater")
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/WorkerService/IWorkerSkillService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/WorkerService/IWorkerSkillService.kt
@@ -1,0 +1,13 @@
+package hr.foi.air.baufind.service.WorkerService
+
+import hr.foi.air.baufind.ws.model.User
+import hr.foi.air.baufind.ws.model.Worker
+import hr.foi.air.baufind.ws.network.TokenProvider
+import hr.foi.air.baufind.ws.request.WorkersSkillBody
+import hr.foi.air.baufind.ws.response.WorkersSkillResponse
+
+interface IWorkerSkillService {
+
+    suspend fun getWorkersBySkill(workersSkillBody: WorkersSkillBody, tokenProvider: TokenProvider): List<Worker>
+    suspend fun getWorkerAccount(worker: Worker, tokenProvider: TokenProvider): User
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/WorkerService/WorkerSkillService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/WorkerService/WorkerSkillService.kt
@@ -11,8 +11,8 @@ class WorkerSkillService : IWorkerSkillService {
     override suspend fun getWorkersBySkill(workersSkillBody: WorkersSkillBody,tokenProvider: TokenProvider): List<Worker> {
         val service = NetworkService.createWorkersService(tokenProvider)
         try {
-            val response = service.getWorkersBySkill(workersSkillBody)
-            return response.data
+            val response = service.getWorkersBySkill(workersSkillBody.title)
+            return response.workerRecords
         }catch (err: Exception){
             err.printStackTrace()
             return emptyList()

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/WorkerService/WorkerSkillService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/WorkerService/WorkerSkillService.kt
@@ -1,0 +1,26 @@
+package hr.foi.air.baufind.service.WorkerService
+
+import hr.foi.air.baufind.ws.model.User
+import hr.foi.air.baufind.ws.model.Worker
+import hr.foi.air.baufind.ws.network.NetworkService
+import hr.foi.air.baufind.ws.network.TokenProvider
+import hr.foi.air.baufind.ws.request.WorkersSkillBody
+import hr.foi.air.baufind.ws.response.WorkersSkillResponse
+
+class WorkerSkillService : IWorkerSkillService {
+    override suspend fun getWorkersBySkill(workersSkillBody: WorkersSkillBody,tokenProvider: TokenProvider): List<Worker> {
+        val service = NetworkService.createWorkersService(tokenProvider)
+        try {
+            val response = service.getWorkersBySkill(workersSkillBody)
+            return response.data
+        }catch (err: Exception) {
+            err.printStackTrace()
+            return emptyList()
+        }
+    }
+
+    override suspend fun getWorkerAccount(worker: Worker,tokenProvider: TokenProvider): User {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/WorkerService/WorkerSkillService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/WorkerService/WorkerSkillService.kt
@@ -13,10 +13,10 @@ class WorkerSkillService : IWorkerSkillService {
         try {
             val response = service.getWorkersBySkill(workersSkillBody)
             return response.data
-        }catch (err: Exception) {
+        }catch (err: Exception){
             err.printStackTrace()
             return emptyList()
-        }
+            }
     }
 
     override suspend fun getWorkerAccount(worker: Worker,tokenProvider: TokenProvider): User {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCard.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCard.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import hr.foi.air.baufind.ws.model.Worker
@@ -29,15 +31,15 @@ fun WorkerCard(
             horizontalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier.fillMaxWidth()
         ){
-            Column(modifier = Modifier.padding(16.dp)) {
-                Text(text = "Ime: ${worker?.name}", fontWeight = FontWeight.Bold)
-                Text(text = "Pozicija: ${worker?.skills}")
-                Text(text = "Lokacija: ${worker?.address}")
-                Text(text = "Broj poslova: ${worker?.numOfJobs}")
+            Column(modifier = Modifier.padding(12.dp,8.dp,8.dp,8.dp)) {
+                Text(text = "Ime: ${worker?.name}", fontWeight = FontWeight.Bold , overflow = TextOverflow.Ellipsis, maxLines = 1)
+                Text(text = "Pozicija: ${worker?.skills}" , overflow = TextOverflow.Ellipsis, maxLines = 1, modifier = Modifier.width(200.dp))
+                Text(text = "Lokacija: ${worker?.address}" , overflow = TextOverflow.Ellipsis, maxLines = 1)
+                Text(text = "Broj poslova: ${worker?.numOfJobs}" , overflow = TextOverflow.Ellipsis, maxLines = 1)
             }
-            Column(modifier = Modifier.padding(8.dp)
-            ) {
-                Text(text = "${worker?.avgRating}", fontWeight = FontWeight.Bold, fontSize = 24.sp)
+            Column(modifier = Modifier.padding(0.dp,8.dp,16.dp,8.dp))
+             {
+                Text(text = "${worker?.avgRating}", fontWeight = FontWeight.Bold, fontSize = 20.sp, overflow = TextOverflow.Ellipsis, maxLines = 1)
 
             }
         }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCard.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCard.kt
@@ -17,7 +17,7 @@ import hr.foi.air.baufind.ws.model.Worker
 
 @Composable
 fun WorkerCard(
-    worker: Worker,
+    worker: Worker?,
     onItemClick: () -> Unit
 ) {
     // Example UI for displaying worker's name and position
@@ -30,14 +30,14 @@ fun WorkerCard(
             modifier = Modifier.fillMaxWidth()
         ){
             Column(modifier = Modifier.padding(16.dp)) {
-                Text(text = "Ime: ${worker.name}", fontWeight = FontWeight.Bold)
-                Text(text = "Pozicija: ${worker.skills}")
-                Text(text = "Lokacija: ${worker.address}")
-                Text(text = "Broj poslova: ${worker.numOfJobs}")
+                Text(text = "Ime: ${worker?.name}", fontWeight = FontWeight.Bold)
+                Text(text = "Pozicija: ${worker?.skills}")
+                Text(text = "Lokacija: ${worker?.address}")
+                Text(text = "Broj poslova: ${worker?.numOfJobs}")
             }
             Column(modifier = Modifier.padding(8.dp)
             ) {
-                Text(text = "${worker.avgRating}", fontWeight = FontWeight.Bold, fontSize = 24.sp)
+                Text(text = "${worker?.avgRating}", fontWeight = FontWeight.Bold, fontSize = 24.sp)
 
             }
         }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCard.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCard.kt
@@ -12,11 +12,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerMock
+import hr.foi.air.baufind.ws.model.Worker
+
 
 @Composable
 fun WorkerCard(
-    worker: WorkerMock.Worker,
+    worker: Worker,
     onItemClick: () -> Unit
 ) {
     // Example UI for displaying worker's name and position
@@ -29,14 +30,14 @@ fun WorkerCard(
             modifier = Modifier.fillMaxWidth()
         ){
             Column(modifier = Modifier.padding(16.dp)) {
-                Text(text = "Ime: ${worker.firstName} ${worker.lastName}", fontWeight = FontWeight.Bold)
+                Text(text = "Ime: ${worker.name}", fontWeight = FontWeight.Bold)
                 Text(text = "Pozicija: ${worker.skills}")
-                Text(text = "Lokacija: ${worker.location}")
+                Text(text = "Lokacija: ${worker.address}")
                 Text(text = "Broj poslova: ${worker.numOfJobs}")
             }
             Column(modifier = Modifier.padding(8.dp)
             ) {
-                Text(text = "${worker.rating}", fontWeight = FontWeight.Bold, fontSize = 24.sp)
+                Text(text = "${worker.avgRating}", fontWeight = FontWeight.Bold, fontSize = 24.sp)
 
             }
         }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -1,7 +1,9 @@
 package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
+import android.text.style.ClickableSpan
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
@@ -18,12 +20,14 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.runtime.*
 import androidx.compose.material3.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -53,7 +57,7 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
     val optionsR = viewModel.optionsR
     val optionsL = viewModel.optionsL
     val workers by viewModel.filteredWorkers
-
+    
     LaunchedEffect(Unit) {
         viewModel.loadWorkers()
     }
@@ -75,7 +79,7 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
                     readOnly = true,
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpandedL) },
                     modifier = Modifier.menuAnchor().fillMaxWidth(),
-                    label = { Text("Location", overflow = TextOverflow.Ellipsis, maxLines = 1) }
+                    label = { Text("Lokacija", overflow = TextOverflow.Ellipsis, maxLines = 1) }
                 )
                 ExposedDropdownMenu(
                     expanded = isExpandedL,
@@ -91,6 +95,19 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
                     }
                 }
             }
+            if(selectedItemL != "" || selectedItemR != "") {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Close icon",
+                    tint = Color.Black,
+                    modifier = Modifier.padding(12.dp, 0.dp).clickable {
+                        viewModel.updateFilteredWorkersR("")
+                        viewModel.updateFilteredWorkersL("")
+                        viewModel.loadWorkers()
+                    }
+
+                )
+            }
             //Desni dropdown meni
             ExposedDropdownMenuBox(
                 expanded = isExpandedR,
@@ -103,7 +120,7 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
                     readOnly = true,
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpandedL) },
                     modifier = Modifier.menuAnchor().fillMaxWidth(),
-                    label = { Text("Sort by", overflow = TextOverflow.Ellipsis, maxLines = 1) }
+                    label = { Text("Sortiraj", overflow = TextOverflow.Ellipsis, maxLines = 1) }
                 )
                 ExposedDropdownMenu(
                     expanded = isExpandedR,

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -74,14 +74,7 @@ fun WorkerSearchScreen(navController: NavController) {
                         DropdownMenuItem(
                             text = { Text(option) },
                             onClick = {
-                                viewModel.selectedItemL.value = option
-                                viewModel.filteredWorkers.value = emptyList()
-                                viewModel.workers.value.forEach {
-                                    if (it.location == option){
-                                        viewModel.filteredWorkers.value += it
-                                    }
-                                }
-                                viewModel.isExpandedL.value = false
+                                viewModel.updateFilteredWorkersL(option)
                             }
                         )
                     }
@@ -109,24 +102,7 @@ fun WorkerSearchScreen(navController: NavController) {
                         DropdownMenuItem(
                             text = { Text(option) },
                             onClick = {
-                                viewModel.selectedItemR.value = option
-                                viewModel.workers.value.forEach {
-                                    if(option == "Ocjena ASC"){
-                                        viewModel.filteredWorkers.value = viewModel.filteredWorkers.value.sortedBy { it.rating }
-
-                                    }
-                                    if(option == "Ocjena DESC") {
-                                        viewModel.filteredWorkers.value =
-                                            viewModel.filteredWorkers.value.sortedByDescending { it.rating }
-                                    }
-                                    if(option == "Broj poslova ASC"){
-                                        viewModel.filteredWorkers.value = viewModel.filteredWorkers.value.sortedBy { it.numOfJobs }
-                                    }
-                                    if(option == "Broj poslova DESC"){
-                                        viewModel.filteredWorkers.value = viewModel.filteredWorkers.value.sortedByDescending { it.numOfJobs }
-                                    }
-                                }
-                                viewModel.isExpandedR.value = false
+                               viewModel.updateFilteredWorkersR(option)
                             }
                         )
                     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -42,7 +42,7 @@ import hr.foi.air.baufind.ws.network.TokenProvider
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider) {
+fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider,position: String) {
     val viewModel: WorkerSearchViewModel = viewModel()
     viewModel.tokenProvider.value = tokenProvider
     //Logika za dropdown meni
@@ -63,7 +63,7 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
     }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Pronađite poziciju x")
+        Text("Pronađite poziciju ${position}")
 
 
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalArrangement = Arrangement.SpaceBetween) {
@@ -178,5 +178,5 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
 @Composable
 fun WorkerSearchScreenPreview() {
     val navController = rememberNavController()
-    WorkerSearchScreen(navController,tokenProvider = object : TokenProvider { override fun getToken(): String? { return null }})
+    WorkerSearchScreen(navController,tokenProvider = object : TokenProvider { override fun getToken(): String? { return null }},"")
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -138,7 +138,7 @@ fun WorkerSearchScreen(navController: NavController) {
             modifier = Modifier.scrollable(state = scrollState, orientation = Orientation.Vertical),
 
         ) {
-            items(workers){
+            items(workers!!){
                 worker -> WorkerCard(worker){
                     //Funkcija se poziva na pritiskom na radnika,| treba je promijeniti u kasnijim fazama i prilikom promjene obrišite dio komentara nakon | znaka.
                    Toast.makeText(context, "Clicked on ${worker.name}", Toast.LENGTH_SHORT).show()

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -6,17 +6,23 @@ import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.runtime.*
 import androidx.compose.material3.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -27,6 +33,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.ui.components.WorkerCard
+import hr.foi.air.baufind.ws.model.Worker
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -106,6 +113,25 @@ fun WorkerSearchScreen(navController: NavController) {
                         )
                     }
                 }
+            }
+        }
+        if (viewModel.workers.value == emptyList<Worker>() || viewModel.filteredWorkers.value == emptyList<Worker>()){
+            Column(
+                modifier = Modifier.padding(16.dp).fillMaxWidth().fillMaxHeight()
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Close,
+                    contentDescription = "No Workers",
+                    tint = Color.Gray,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    text = "Nema radnika koje pretražujete",
+                    color = Color.Gray,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold
+                )
             }
         }
         //Lista radnika i prikaz i callback za pritisak

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -70,7 +70,6 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
     LaunchedEffect(Unit) {
         isLoading = true
         viewModel.loadWorkers()
-        delay(2000)
         isLoading = false
     }
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -41,16 +41,11 @@ fun WorkerSearchScreen(navController: NavController) {
     val scrollState = rememberScrollState()
     val selectedItemL by viewModel.selectedItemL
     val selectedItemR by viewModel.selectedItemR
-    val workers by viewModel.workers
+    val workers by viewModel.filteredWorkers
     val context = LocalContext.current
     // Opcije za dropdown meni
-    val optionsR = listOf("Ocjena ASC", "Ocjena DESC", "Broj poslova ASC", "Broj poslova DESC")
-    val optionsL = listOf("Zagrebačka", "Krapinsko-zagorska", "Sisacko-moslavačka", "Karlovačka", "Varaždinska",
-         "Bjelovarsko-bilogorska", "Primorsko-goranska", "Ličko-senjska",
-        "Virovitičko-podravska", "Osječko-baranjska", "Šibensko-kninska", "Vukovarsko-srijemska",
-        "Zadarska", "Međimurska", "Dubrovničko-neretvanska", "Istarska", "Požeško-slavonska",
-        "Splitsko-dalmatinska", "Zagrebački grad"
-    )
+    val optionsR = viewModel.optionsR
+    val optionsL = viewModel.optionsL
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text("Pronađite poziciju x")
@@ -80,6 +75,12 @@ fun WorkerSearchScreen(navController: NavController) {
                             text = { Text(option) },
                             onClick = {
                                 viewModel.selectedItemL.value = option
+                                viewModel.filteredWorkers.value = emptyList()
+                                viewModel.workers.value.forEach {
+                                    if (it.location == option){
+                                        viewModel.filteredWorkers.value += it
+                                    }
+                                }
                                 viewModel.isExpandedL.value = false
                             }
                         )
@@ -109,6 +110,22 @@ fun WorkerSearchScreen(navController: NavController) {
                             text = { Text(option) },
                             onClick = {
                                 viewModel.selectedItemR.value = option
+                                viewModel.workers.value.forEach {
+                                    if(option == "Ocjena ASC"){
+                                        viewModel.filteredWorkers.value = viewModel.filteredWorkers.value.sortedBy { it.rating }
+
+                                    }
+                                    if(option == "Ocjena DESC") {
+                                        viewModel.filteredWorkers.value =
+                                            viewModel.filteredWorkers.value.sortedByDescending { it.rating }
+                                    }
+                                    if(option == "Broj poslova ASC"){
+                                        viewModel.filteredWorkers.value = viewModel.filteredWorkers.value.sortedBy { it.numOfJobs }
+                                    }
+                                    if(option == "Broj poslova DESC"){
+                                        viewModel.filteredWorkers.value = viewModel.filteredWorkers.value.sortedByDescending { it.numOfJobs }
+                                    }
+                                }
                                 viewModel.isExpandedR.value = false
                             }
                         )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -39,14 +39,16 @@ import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.ui.components.WorkerCard
 import hr.foi.air.baufind.ws.model.Worker
 import hr.foi.air.baufind.ws.network.TokenProvider
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider,position: String) {
+fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider,skill: String) {
     val viewModel: WorkerSearchViewModel = viewModel()
     viewModel.tokenProvider.value = tokenProvider
     //Logika za dropdown meni
     /// Preporučeno je za manji broj opcija koristiti chip
+    viewModel.skill.value = skill
     val isExpandedL by viewModel.isExpandedL
     val isExpandedR by viewModel.isExpandedR
     val scrollState = rememberScrollState()
@@ -57,13 +59,13 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
     val optionsR = viewModel.optionsR
     val optionsL = viewModel.optionsL
     val workers by viewModel.filteredWorkers
-    
+    val coroutine = rememberCoroutineScope()
     LaunchedEffect(Unit) {
         viewModel.loadWorkers()
     }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Pronađite poziciju ${position}")
+        Text("Pronađite poziciju ${skill}")
 
 
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalArrangement = Arrangement.SpaceBetween) {
@@ -103,7 +105,9 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
                     modifier = Modifier.padding(12.dp, 0.dp).clickable {
                         viewModel.updateFilteredWorkersR("")
                         viewModel.updateFilteredWorkersL("")
-                        viewModel.loadWorkers()
+                        coroutine.launch {
+                            viewModel.loadWorkers()
+                        }
                     }
 
                 )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -1,5 +1,6 @@
 package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.scrollable
@@ -33,12 +34,13 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.ui.components.WorkerCard
 import hr.foi.air.baufind.ws.model.Worker
+import hr.foi.air.baufind.ws.network.TokenProvider
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WorkerSearchScreen(navController: NavController) {
+fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider) {
     val viewModel: WorkerSearchViewModel = viewModel()
-
+    viewModel.tokenProvider.value = tokenProvider
     //Logika za dropdown meni
     /// Preporučeno je za manji broj opcija koristiti chip
     val isExpandedL by viewModel.isExpandedL
@@ -46,11 +48,15 @@ fun WorkerSearchScreen(navController: NavController) {
     val scrollState = rememberScrollState()
     val selectedItemL by viewModel.selectedItemL
     val selectedItemR by viewModel.selectedItemR
-    val workers by viewModel.filteredWorkers
     val context = LocalContext.current
     // Opcije za dropdown meni
     val optionsR = viewModel.optionsR
     val optionsL = viewModel.optionsL
+    val workers by viewModel.filteredWorkers
+
+    LaunchedEffect(Unit) {
+        viewModel.loadWorkers()
+    }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
         Text("Pronađite poziciju x")
@@ -138,7 +144,9 @@ fun WorkerSearchScreen(navController: NavController) {
             modifier = Modifier.scrollable(state = scrollState, orientation = Orientation.Vertical),
 
         ) {
-            items(workers!!){
+
+            items(workers ?: emptyList()){
+
                 worker -> WorkerCard(worker){
                     //Funkcija se poziva na pritiskom na radnika,| treba je promijeniti u kasnijim fazama i prilikom promjene obrišite dio komentara nakon | znaka.
                    Toast.makeText(context, "Clicked on ${worker.name}", Toast.LENGTH_SHORT).show()
@@ -146,11 +154,12 @@ fun WorkerSearchScreen(navController: NavController) {
             }
         }
     }
+
 }
 
 @Preview(showBackground = true)
 @Composable
 fun WorkerSearchScreenPreview() {
     val navController = rememberNavController()
-    WorkerSearchScreen(navController)
+    WorkerSearchScreen(navController,tokenProvider = object : TokenProvider { override fun getToken(): String? { return null }})
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.runtime.*
 import androidx.compose.material3.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
-import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerMock
 import hr.foi.air.baufind.ui.components.WorkerCard
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -117,7 +116,7 @@ fun WorkerSearchScreen(navController: NavController) {
             items(workers){
                 worker -> WorkerCard(worker){
                     //Funkcija se poziva na pritiskom na radnika,| treba je promijeniti u kasnijim fazama i prilikom promjene obrišite dio komentara nakon | znaka.
-                   Toast.makeText(context, "Clicked on ${worker.firstName} ${worker.lastName}", Toast.LENGTH_SHORT).show()
+                   Toast.makeText(context, "Clicked on ${worker.name}", Toast.LENGTH_SHORT).show()
                }
             }
         }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -145,7 +145,7 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
 
         ) {
 
-            items(workers ?: emptyList()){
+            items(workers){
 
                 worker -> WorkerCard(worker){
                     //Funkcija se poziva na pritiskom na radnika,| treba je promijeniti u kasnijim fazama i prilikom promjene obrišite dio komentara nakon | znaka.

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -1,14 +1,22 @@
 package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
+import WorkerMock
+import android.content.SharedPreferences
+import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerTitleMock
+import hr.foi.air.baufind.service.WorkerService.WorkerSkillService
 import hr.foi.air.baufind.ws.model.Worker
+import hr.foi.air.baufind.ws.network.AppTokenProvider
+import hr.foi.air.baufind.ws.network.TokenProvider
+import hr.foi.air.baufind.ws.request.WorkersSkillBody
 import kotlinx.coroutines.launch
 
-class WorkerSearchViewModel : ViewModel() {
-
+class WorkerSearchViewModel() : ViewModel() {
+    val tokenProvider: MutableState<TokenProvider?> = mutableStateOf(null)
     val isExpandedL: MutableState<Boolean> = mutableStateOf(false)
     val isExpandedR: MutableState<Boolean> = mutableStateOf(false)
     val selectedItemL: MutableState<String> = mutableStateOf("")
@@ -20,40 +28,45 @@ class WorkerSearchViewModel : ViewModel() {
         "Zadarska", "Međimurska", "Dubrovničko-neretvanska", "Istarska", "Požeško-slavonska",
         "Splitsko-dalmatinska", "Grad Zagreb", "Splitsko-dalmatinska",
     )
-
-    val workers: MutableState<List<Worker>?> = mutableStateOf(null)
-    val filteredWorkers: MutableState<List<Worker>?> = mutableStateOf(workers.value)
+    val service = WorkerSkillService()
+    val workers: MutableState<List<Worker>> = mutableStateOf(emptyList())
+    val filteredWorkers: MutableState<List<Worker>> = mutableStateOf(emptyList())
     fun updateFilteredWorkersL(option: String) {
         selectedItemL.value = option
         filteredWorkers.value = emptyList()
-        workers.value!!.forEach {
+        Log.e("AAA", workers.value.toString())
+        Log.e("filteredWorkers", filteredWorkers.value.toString())
+        workers.value.forEach {
             if (it.address == option){
-                filteredWorkers.value = filteredWorkers.value!! + it
+                filteredWorkers.value += it
+                Log.e("filteredWorkers", filteredWorkers.value.toString())
             }
         }
         isExpandedL.value = false
     }
-    fun fetchWorkers() {
-        viewModelScope.launch {
+     fun loadWorkers() {
+         Log.e("loadWorkers", workers.value.toString())
+         workers.value = WorkerMock.workers
+         filteredWorkers.value = workers.value
 
-        }
     }
     fun updateFilteredWorkersR(option: String) {
         selectedItemR.value = option
-        workers.value?.forEach {
+        Log.e("AAAAAAAAAAA", workers.value.toString())
+        workers.value.forEach {
             if(option == "Ocjena ASC"){
-                filteredWorkers.value = filteredWorkers.value!!.sortedBy { it.avgRating }
+                filteredWorkers.value = filteredWorkers.value.sortedBy { it.avgRating }
 
             }
             if(option == "Ocjena DESC") {
                 filteredWorkers.value =
-                   filteredWorkers.value!!.sortedByDescending { it.avgRating }
+                   filteredWorkers.value.sortedByDescending { it.avgRating }
             }
             if(option == "Broj poslova ASC"){
-                filteredWorkers.value = filteredWorkers.value!!.sortedBy { it.numOfJobs }
+                filteredWorkers.value = filteredWorkers.value.sortedBy { it.numOfJobs }
             }
             if(option == "Broj poslova DESC"){
-                filteredWorkers.value = filteredWorkers.value!!.sortedByDescending { it.numOfJobs }
+                filteredWorkers.value = filteredWorkers.value.sortedByDescending { it.numOfJobs }
             }
         }
         isExpandedR.value = false

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -10,10 +10,16 @@ class WorkerSearchViewModel : ViewModel() {
 
     val isExpandedL: MutableState<Boolean> = mutableStateOf(false)
     val isExpandedR: MutableState<Boolean> = mutableStateOf(false)
-
-
     val selectedItemL: MutableState<String> = mutableStateOf("")
     val selectedItemR: MutableState<String> = mutableStateOf("")
+    val optionsR: List<String> = listOf("Ocjena ASC", "Ocjena DESC", "Broj poslova ASC", "Broj poslova DESC")
+    val optionsL: List<String> = listOf("Zagrebačka", "Krapinsko-zagorska", "Sisačko-moslavačka", "Karlovačka", "Varaždinska",
+        "Bjelovarsko-bilogorska", "Primorsko-goranska", "Ličko-senjska",
+        "Virovitičko-podravska", "Osječko-baranjska", "Šibensko-kninska", "Vukovarsko-srijemska",
+        "Zadarska", "Međimurska", "Dubrovničko-neretvanska", "Istarska", "Požeško-slavonska",
+        "Splitsko-dalmatinska", "Grad Zagreb", "Splitsko-dalmatinska",
+    )
 
     val workers: MutableState<List<WorkerMock.Worker>> = mutableStateOf(WorkerMock.workers)
+    val filteredWorkers: MutableState<List<WorkerMock.Worker>> = mutableStateOf(workers.value)
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -22,4 +22,34 @@ class WorkerSearchViewModel : ViewModel() {
 
     val workers: MutableState<List<WorkerMock.Worker>> = mutableStateOf(WorkerMock.workers)
     val filteredWorkers: MutableState<List<WorkerMock.Worker>> = mutableStateOf(workers.value)
+    fun updateFilteredWorkersL(option: String) {
+        selectedItemL.value = option
+        filteredWorkers.value = emptyList()
+        workers.value.forEach {
+            if (it.location == option){
+                filteredWorkers.value += it
+            }
+        }
+        isExpandedL.value = false
+    }
+    fun updateFilteredWorkersR(option: String) {
+        selectedItemR.value = option
+        workers.value.forEach {
+            if(option == "Ocjena ASC"){
+                filteredWorkers.value = filteredWorkers.value.sortedBy { it.rating }
+
+            }
+            if(option == "Ocjena DESC") {
+                filteredWorkers.value =
+                   filteredWorkers.value.sortedByDescending { it.rating }
+            }
+            if(option == "Broj poslova ASC"){
+                filteredWorkers.value = filteredWorkers.value.sortedBy { it.numOfJobs }
+            }
+            if(option == "Broj poslova DESC"){
+                filteredWorkers.value = filteredWorkers.value.sortedByDescending { it.numOfJobs }
+            }
+        }
+        isExpandedR.value = false
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -8,9 +8,11 @@ import androidx.lifecycle.ViewModel
 import hr.foi.air.baufind.service.WorkerService.WorkerSkillService
 import hr.foi.air.baufind.ws.model.Worker
 import hr.foi.air.baufind.ws.network.TokenProvider
+import hr.foi.air.baufind.ws.request.WorkersSkillBody
 
 
 class WorkerSearchViewModel() : ViewModel() {
+    val skill : MutableState<String> = mutableStateOf("")
     val tokenProvider: MutableState<TokenProvider?> = mutableStateOf(null)
     val isExpandedL: MutableState<Boolean> = mutableStateOf(false)
     val isExpandedR: MutableState<Boolean> = mutableStateOf(false)
@@ -40,11 +42,18 @@ class WorkerSearchViewModel() : ViewModel() {
         isExpandedL.value = false
     }
     //Funkcija za učitavanje radnika
-     fun loadWorkers() {
+     fun loadWorkersMock() {
          Log.e("loadWorkers", workers.value.toString())
          workers.value = WorkerMock.workers
          filteredWorkers.value = workers.value
 
+    }
+    suspend fun loadWorkers() {
+        Log.e("tokenss", tokenProvider.value.toString())
+        workers.value =  service.getWorkersBySkill(workersSkillBody = WorkersSkillBody(skill.value),
+            tokenProvider = tokenProvider.value!!)
+        Log.e("getWorkersBySkill", workers.value.toString())
+        filteredWorkers.value = workers.value
     }
     //Funkcija za filtriranje radnika
     fun updateFilteredWorkersR(option: String) {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -3,7 +3,9 @@ package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import hr.foi.air.baufind.ws.model.Worker
+import kotlinx.coroutines.launch
 
 class WorkerSearchViewModel : ViewModel() {
 
@@ -19,34 +21,39 @@ class WorkerSearchViewModel : ViewModel() {
         "Splitsko-dalmatinska", "Grad Zagreb", "Splitsko-dalmatinska",
     )
 
-    val workers: MutableState<List<Worker>> = mutableStateOf(WorkerMock.workers)
-    val filteredWorkers: MutableState<List<Worker>> = mutableStateOf(workers.value)
+    val workers: MutableState<List<Worker>?> = mutableStateOf(null)
+    val filteredWorkers: MutableState<List<Worker>?> = mutableStateOf(workers.value)
     fun updateFilteredWorkersL(option: String) {
         selectedItemL.value = option
         filteredWorkers.value = emptyList()
-        workers.value.forEach {
+        workers.value!!.forEach {
             if (it.address == option){
-                filteredWorkers.value += it
+                filteredWorkers.value = filteredWorkers.value!! + it
             }
         }
         isExpandedL.value = false
     }
+    fun fetchWorkers() {
+        viewModelScope.launch {
+
+        }
+    }
     fun updateFilteredWorkersR(option: String) {
         selectedItemR.value = option
-        workers.value.forEach {
+        workers.value?.forEach {
             if(option == "Ocjena ASC"){
-                filteredWorkers.value = filteredWorkers.value.sortedBy { it.avgRating }
+                filteredWorkers.value = filteredWorkers.value!!.sortedBy { it.avgRating }
 
             }
             if(option == "Ocjena DESC") {
                 filteredWorkers.value =
-                   filteredWorkers.value.sortedByDescending { it.avgRating }
+                   filteredWorkers.value!!.sortedByDescending { it.avgRating }
             }
             if(option == "Broj poslova ASC"){
-                filteredWorkers.value = filteredWorkers.value.sortedBy { it.numOfJobs }
+                filteredWorkers.value = filteredWorkers.value!!.sortedBy { it.numOfJobs }
             }
             if(option == "Broj poslova DESC"){
-                filteredWorkers.value = filteredWorkers.value.sortedByDescending { it.numOfJobs }
+                filteredWorkers.value = filteredWorkers.value!!.sortedByDescending { it.numOfJobs }
             }
         }
         isExpandedR.value = false

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -1,19 +1,14 @@
 package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
 import WorkerMock
-import android.content.SharedPreferences
 import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerTitleMock
 import hr.foi.air.baufind.service.WorkerService.WorkerSkillService
 import hr.foi.air.baufind.ws.model.Worker
-import hr.foi.air.baufind.ws.network.AppTokenProvider
 import hr.foi.air.baufind.ws.network.TokenProvider
-import hr.foi.air.baufind.ws.request.WorkersSkillBody
-import kotlinx.coroutines.launch
+
 
 class WorkerSearchViewModel() : ViewModel() {
     val tokenProvider: MutableState<TokenProvider?> = mutableStateOf(null)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -2,7 +2,6 @@ package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import hr.foi.air.baufind.ws.model.Worker
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import hr.foi.air.baufind.mock.WorkerSearchMock.WorkerMock
+import hr.foi.air.baufind.ws.model.Worker
 
 class WorkerSearchViewModel : ViewModel() {
 
@@ -20,13 +20,13 @@ class WorkerSearchViewModel : ViewModel() {
         "Splitsko-dalmatinska", "Grad Zagreb", "Splitsko-dalmatinska",
     )
 
-    val workers: MutableState<List<WorkerMock.Worker>> = mutableStateOf(WorkerMock.workers)
-    val filteredWorkers: MutableState<List<WorkerMock.Worker>> = mutableStateOf(workers.value)
+    val workers: MutableState<List<Worker>> = mutableStateOf(WorkerMock.workers)
+    val filteredWorkers: MutableState<List<Worker>> = mutableStateOf(workers.value)
     fun updateFilteredWorkersL(option: String) {
         selectedItemL.value = option
         filteredWorkers.value = emptyList()
         workers.value.forEach {
-            if (it.location == option){
+            if (it.address == option){
                 filteredWorkers.value += it
             }
         }
@@ -36,12 +36,12 @@ class WorkerSearchViewModel : ViewModel() {
         selectedItemR.value = option
         workers.value.forEach {
             if(option == "Ocjena ASC"){
-                filteredWorkers.value = filteredWorkers.value.sortedBy { it.rating }
+                filteredWorkers.value = filteredWorkers.value.sortedBy { it.avgRating }
 
             }
             if(option == "Ocjena DESC") {
                 filteredWorkers.value =
-                   filteredWorkers.value.sortedByDescending { it.rating }
+                   filteredWorkers.value.sortedByDescending { it.avgRating }
             }
             if(option == "Broj poslova ASC"){
                 filteredWorkers.value = filteredWorkers.value.sortedBy { it.numOfJobs }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -31,10 +31,10 @@ class WorkerSearchViewModel() : ViewModel() {
     val service = WorkerSkillService()
     val workers: MutableState<List<Worker>> = mutableStateOf(emptyList())
     val filteredWorkers: MutableState<List<Worker>> = mutableStateOf(emptyList())
+    //Funkcija za filtriranje radnika
     fun updateFilteredWorkersL(option: String) {
         selectedItemL.value = option
         filteredWorkers.value = emptyList()
-        Log.e("AAA", workers.value.toString())
         Log.e("filteredWorkers", filteredWorkers.value.toString())
         workers.value.forEach {
             if (it.address == option){
@@ -44,15 +44,16 @@ class WorkerSearchViewModel() : ViewModel() {
         }
         isExpandedL.value = false
     }
+    //Funkcija za učitavanje radnika
      fun loadWorkers() {
          Log.e("loadWorkers", workers.value.toString())
          workers.value = WorkerMock.workers
          filteredWorkers.value = workers.value
 
     }
+    //Funkcija za filtriranje radnika
     fun updateFilteredWorkersR(option: String) {
         selectedItemR.value = option
-        Log.e("AAAAAAAAAAA", workers.value.toString())
         workers.value.forEach {
             if(option == "Ocjena ASC"){
                 filteredWorkers.value = filteredWorkers.value.sortedBy { it.avgRating }

--- a/Software/Frontend/app/src/test/java/hr/foi/air/baufind/ExampleUnitTest.kt
+++ b/Software/Frontend/app/src/test/java/hr/foi/air/baufind/ExampleUnitTest.kt
@@ -12,6 +12,6 @@ import org.junit.Assert.*
 class ExampleUnitTest {
     @Test
     fun addition_isCorrect() {
-        assertEquals(4, 2 + 2)
+
     }
 }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/Worker.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/Worker.kt
@@ -1,0 +1,13 @@
+package hr.foi.air.baufind.ws.model
+
+data class Worker(
+    val id: Int,
+    val name: String,
+    val email: String,
+    val phone: String,
+    val address: String,
+    val numOfJobs: Int,
+    val skills: List<String>,
+    val availability: String,
+    val avgRating: Double
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/Worker.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/Worker.kt
@@ -3,11 +3,8 @@ package hr.foi.air.baufind.ws.model
 data class Worker(
     val id: Int,
     val name: String,
-    val email: String,
-    val phone: String,
     val address: String,
     val numOfJobs: Int,
-    val skills: List<String>,
-    val availability: String,
+    val skills: String,
     val avgRating: Double
 )

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/NetworkService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/NetworkService.kt
@@ -20,6 +20,10 @@ object NetworkService {
             .build()
     }
 
+    fun createWorkersService(tokenProvider: TokenProvider): WorkersSkillService {
+        return createRetrofit(tokenProvider).create(WorkersSkillService::class.java)
+    }
+
     fun createAuthService(tokenProvider: TokenProvider): AuthenticationService {
         return createRetrofit(tokenProvider).create(AuthenticationService::class.java)
     }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/WorkersSkillService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/WorkersSkillService.kt
@@ -1,12 +1,12 @@
 package hr.foi.air.baufind.ws.network
 
-import hr.foi.air.baufind.ws.model.Worker
 import hr.foi.air.baufind.ws.request.WorkersSkillBody
+import hr.foi.air.baufind.ws.response.WorkersSkillResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 
 interface WorkersSkillService {
 
     @GET("workers/skills")
-    suspend fun getWorkersBySkill(@Body workersSkillBody: WorkersSkillBody): List<Worker>
+    suspend fun getWorkersBySkill(@Body workersSkillBody: WorkersSkillBody): WorkersSkillResponse
 }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/WorkersSkillService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/WorkersSkillService.kt
@@ -4,7 +4,6 @@ import hr.foi.air.baufind.ws.model.Worker
 import hr.foi.air.baufind.ws.request.WorkersSkillBody
 import retrofit2.http.Body
 import retrofit2.http.GET
-import retrofit2.http.Query
 
 interface WorkersSkillService {
 

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/WorkersSkillService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/WorkersSkillService.kt
@@ -1,12 +1,13 @@
 package hr.foi.air.baufind.ws.network
 
-import hr.foi.air.baufind.ws.request.WorkersSkillBody
+
 import hr.foi.air.baufind.ws.response.WorkersSkillResponse
-import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Path
+
 
 interface WorkersSkillService {
 
-    @GET("workers/skills")
-    suspend fun getWorkersBySkill(@Body workersSkillBody: WorkersSkillBody): WorkersSkillResponse
+    @GET("/workers/{skill}")
+    suspend fun getWorkersBySkill(@Path("skill") skill: String): WorkersSkillResponse
 }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/WorkersSkillService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/WorkersSkillService.kt
@@ -1,0 +1,13 @@
+package hr.foi.air.baufind.ws.network
+
+import hr.foi.air.baufind.ws.model.Worker
+import hr.foi.air.baufind.ws.request.WorkersSkillBody
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface WorkersSkillService {
+
+    @GET("workers/skills")
+    suspend fun getWorkersBySkill(@Body workersSkillBody: WorkersSkillBody): List<Worker>
+}

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/request/WorkersSkillBody.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/request/WorkersSkillBody.kt
@@ -1,0 +1,5 @@
+package hr.foi.air.baufind.ws.request
+
+data class WorkersSkillBody(
+    val title: String
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/WorkersSkillResponse.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/WorkersSkillResponse.kt
@@ -3,8 +3,6 @@ package hr.foi.air.baufind.ws.response
 import hr.foi.air.baufind.ws.model.Worker
 
 data class WorkersSkillResponse(
-    val success: String,
-    val error: String,
-    val data: List<Worker>
-
+    val workerRecords: List<Worker>,
+    val error: String
 )

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/WorkersSkillResponse.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/WorkersSkillResponse.kt
@@ -1,0 +1,10 @@
+package hr.foi.air.baufind.ws.response
+
+import hr.foi.air.baufind.ws.model.Worker
+
+data class WorkersSkillResponse(
+    val success: String,
+    val error: String,
+    val data: List<Worker>
+
+)


### PR DESCRIPTION
BAUF 11 je implementiran, trenutno je hardokodirana vještina: Vodoinstalater, no pri izgradnji prethodnih ekrana taj problem će se otkloniti. Bauf 11 je povezan sa backendom, na backendu je kreirana nova ruta i koristi JWT.
![Snimka zaslona 2024-12-02 004243](https://github.com/user-attachments/assets/50eb45db-1cb0-458f-885c-9bb070c2bfcb)
Workers ruta dobavlja sve podatke o korisicima za određenim vještinama kao na BAUF 11 Figma skici
![Snimka zaslona 2024-12-02 004407](https://github.com/user-attachments/assets/156cf6f1-ca4f-407f-a4a0-870279044e7e)
Korisnik može filtrirati po lokaciji i po ocjenama, broju poslova. Pritisak na korisnika bi trebao otvoriti njegov profil no trenutačno profil nije još implementiran.
Nakon implementacije ovaj ekran izgleda ovako
![Snimka zaslona 2024-12-02 004852](https://github.com/user-attachments/assets/3a55b556-90d9-47af-b2ad-effbbdb631ba)
