### PR TITLE
Bauf 11 kao poslodavac elim pretra ivati dostupne radnike uz pomo filtera kako bih mogao prona i odgovaraju eg kandidata

### DIFF
--- a/Software/Backend/DataAccessLayer/Infrastructure/WorkerRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/WorkerRepository.cs
@@ -25,8 +25,13 @@ namespace DataAccessLayer.Infrastructure {
         /// Returns WorkerModel - Radnik koji zadovoljava određenu vještinu i njegove informacije o bivšim poslovima i prosječnoj ocjeni
          public List<WorkerModel>? GetWorkers(string skill) 
         {
+            string trimmed = skill.Trim('[', ']');
+            var elements = trimmed.Split(',')
+                                  .Select(e => e.Trim()) 
+                                  .Select(e => $"'{e}'"); 
 
-            string query = $"SELECT \r\n    u.id, \r\n    u.name, \r\n    u.address, \r\n    COUNT(j.id) AS numOfJobs, \r\n    s.title AS skills,  \r\n    COALESCE(CAST(AVG(CAST(wr.rating AS DECIMAL(3, 2))) AS DECIMAL(5, 2)), 0.00) AS avgRating\r\nFROM \r\n    app_user u\r\nLEFT JOIN \r\n    working w ON u.id = w.worker_id\r\nLEFT JOIN \r\n    job j ON w.job_id = j.id\r\nLEFT JOIN \r\n    worker_review wr ON w.id = wr.working_id\r\nLEFT JOIN \r\n    user_skill us ON u.id = us.user_id\r\nLEFT JOIN \r\n    skill s ON us.skill_id = s.id\r\nWHERE \r\n    s.title = '{skill}'\r\nGROUP BY \r\n    u.id, u.name, u.address, s.title;";
+            string skills = $"({string.Join(", ", elements)})";
+            string query = $"SELECT \r\n    u.id, \r\n    u.name, \r\n    u.address, \r\n    COUNT(j.id) AS numOfJobs, \r\n    MAX('\"' + s.title + '\"') AS skills, \r\n    COALESCE(CAST(AVG(CAST(wr.rating AS DECIMAL(3, 2))) AS DECIMAL(5, 2)), 0.00) AS avgRating\r\nFROM \r\n    app_user u\r\nLEFT JOIN \r\n    working w ON u.id = w.worker_id\r\nLEFT JOIN \r\n    job j ON w.job_id = j.id\r\nLEFT JOIN \r\n    worker_review wr ON w.id = wr.working_id\r\nLEFT JOIN \r\n    user_skill us ON u.id = us.user_id\r\nLEFT JOIN \r\n    skill s ON us.skill_id = s.id\r\nWHERE \r\n    s.title IN {skills} \r\nGROUP BY \r\n    u.id, u.name, u.address;";
             using (var reader = dB.ExecuteReader(query)) {
                 var result = new List<WorkerModel>();
                 while (reader.Read()) {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -20,6 +20,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.google.gson.Gson
 import hr.foi.air.baufind.navigation.BottomNavigationBar
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobAddSkillsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
@@ -40,7 +41,7 @@ class MainActivity : ComponentActivity() {
         val tokenProvider = AppTokenProvider(sharedPreferences)
         val jwtToken = sharedPreferences.getString("jwt_token", null)
         val userProfileViewModel = UserProfileViewModel(tokenProvider)
-
+        val gson: Gson = Gson()
         setContent {
             val jobViewModel : JobViewModel = viewModel()
             val navController = rememberNavController()
@@ -50,7 +51,16 @@ class MainActivity : ComponentActivity() {
             BaufindTheme {
                 Scaffold(
                     bottomBar = {
-                        if (currentRoute in listOf("workersSearchScreen")) {
+                        if (currentRoute in listOf("jobPositionsLocationScreen")) {
+                            BottomNavigationBar(navController = navController)
+                        }
+                        if (currentRoute in listOf("jobAddSkillsScreen")) {
+                            BottomNavigationBar(navController = navController)
+                        }
+                        if (currentRoute in listOf("jobDetailsScreen")) {
+                            BottomNavigationBar(navController = navController)
+                        }
+                        if (currentRoute in listOf("myUserProfileScreen")) {
                             BottomNavigationBar(navController = navController)
                         }
                     }
@@ -77,7 +87,12 @@ class MainActivity : ComponentActivity() {
 
                             composable("workersSearchScreen/{position}",
                                 arguments = listOf(navArgument("position") { type = NavType.StringType })
-                                ) { WorkerSearchScreen(navController,tokenProvider,"Vodoinstalater") }
+                                ) { backStackEntry ->
+                                val position = backStackEntry.arguments?.getString("position")
+                                Log.d("ugbug1", "Position: $position")
+                                val deserializedList = gson.fromJson(position, Array<Int>::class.java).toList()
+                                WorkerSearchScreen(navController,tokenProvider,deserializedList)
+                            }
                             composable("jobDetailsScreen") { JobDetailsScreen(navController, jobViewModel) }
                             composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController, jobViewModel, tokenProvider) }
                             composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel, tokenProvider) }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -14,10 +14,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import hr.foi.air.baufind.navigation.BottomNavigationBar
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobAddSkillsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
@@ -73,7 +75,9 @@ class MainActivity : ComponentActivity() {
                             composable("editUserProfileScreen") { EditProfileScreen(navController, this@MainActivity, tokenProvider, userProfileViewModel) }
 
 
-                            composable("workersSearchScreen") { WorkerSearchScreen(navController,tokenProvider,"Vodoinstalater") }
+                            composable("workersSearchScreen/{position}",
+                                arguments = listOf(navArgument("position") { type = NavType.StringType })
+                                ) { WorkerSearchScreen(navController,tokenProvider,"Vodoinstalater") }
                             composable("jobDetailsScreen") { JobDetailsScreen(navController, jobViewModel) }
                             composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController, jobViewModel, tokenProvider) }
                             composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel, tokenProvider) }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
@@ -18,7 +18,7 @@ fun BottomNavigationBar(navController: NavController) {
 
     val items = listOf(
         BottomNavItem(
-            route = "workersSearchScreen",
+            route = "jobPositionsLocationScreen",
             icon = IconType.Vector(imageVector = Icons.Default.Search),
             label = "Search"),
             BottomNavItem(

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
@@ -18,7 +18,7 @@ fun BottomNavigationBar(navController: NavController) {
 
     val items = listOf(
         BottomNavItem(
-            route = "jobPositionsLocationScreen",
+            route = "jobDetailsScreen",
             icon = IconType.Vector(imageVector = Icons.Default.Search),
             label = "Search"),
             BottomNavItem(

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
@@ -1,6 +1,7 @@
 package hr.foi.air.baufind.navigation
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
@@ -19,11 +20,12 @@ fun BottomNavigationBar(navController: NavController) {
     val items = listOf(
         BottomNavItem(
             route = "jobDetailsScreen",
-            icon = IconType.Vector(imageVector = Icons.Default.Search),
-            label = "Search"),
+            icon = IconType.Vector(imageVector = Icons.Default.Add),
+            label = "Add job"),
             BottomNavItem(
             route = "myUserProfileScreen",
-            icon = IconType.Vector(imageVector = Icons.Default.Person), label = "Profile")
+            icon = IconType.Vector(imageVector = Icons.Default.Person), label = "Profile"),
+
 
     )
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
@@ -17,12 +17,14 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -89,7 +91,7 @@ fun JobDetailsScreen(navController: NavController, jobViewModel: JobViewModel){
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(22.dp).scrollable(scrollState, orientation = Orientation.Vertical),
+            .padding(22.dp,0.dp).verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally,
 
     ){

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobDetailsScreen.kt
@@ -7,6 +7,8 @@ import android.provider.MediaStore
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -20,6 +22,7 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -82,12 +85,13 @@ fun JobDetailsScreen(navController: NavController, jobViewModel: JobViewModel){
         }
         return valid
     }
-
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(22.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+            .padding(22.dp).scrollable(scrollState, orientation = Orientation.Vertical),
+        horizontalAlignment = Alignment.CenterHorizontally,
+
     ){
         Text(
             text ="Novi posao",

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -1,5 +1,6 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
+import android.util.Log
 import com.google.gson.Gson
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
@@ -154,7 +155,8 @@ fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobVi
                             tokenProvider
                         )
                         if (response.added) {
-                            var positions = gson.toJson(jobViewModel.jobPositions)
+                            var positions = gson.toJson(jobViewModel.getPositionsArray())
+                            Log.d("ugbug12", "Position: $positions")
                             navController.navigate("workersSearchScreen/${positions}")
                         } else {
                             Toast.makeText(context, response.message, Toast.LENGTH_LONG).show()

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -1,5 +1,6 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
+import com.google.gson.Gson
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -43,7 +44,7 @@ fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobVi
     var latError by remember { mutableStateOf("") }
     var longError by remember { mutableStateOf("") }
     var context = LocalContext.current
-
+    val gson = Gson()
     var latText by remember { mutableStateOf("") }
     var longText by remember { mutableStateOf("") }
 
@@ -153,7 +154,8 @@ fun JobPositionsLocationScreen(navController: NavController, jobViewModel: JobVi
                             tokenProvider
                         )
                         if (response.added) {
-                            navController.navigate("workersSearchScreen")
+                            var positions = gson.toJson(jobViewModel.jobPositions)
+                            navController.navigate("workersSearchScreen/${positions}")
                         } else {
                             Toast.makeText(context, response.message, Toast.LENGTH_LONG).show()
                         }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/LoginScreen/LoginScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/LoginScreen/LoginScreen.kt
@@ -129,7 +129,7 @@ fun LoginScreen(navController: NavController, context : Context, tokenProvider: 
                         )
                         if (response.successfulLogin){
                             JwtService.saveJwt(context, response.jwt)
-                            navController.navigate("jobPositionsLocationScreen")
+                            navController.navigate("jobDetailsScreen")
                         }
                         else {
                             email = ""

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/LoginScreen/LoginScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/LoginScreen/LoginScreen.kt
@@ -129,7 +129,7 @@ fun LoginScreen(navController: NavController, context : Context, tokenProvider: 
                         )
                         if (response.successfulLogin){
                             JwtService.saveJwt(context, response.jwt)
-                            navController.navigate("workersSearchScreen")
+                            navController.navigate("jobPositionsLocationScreen")
                         }
                         else {
                             email = ""

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -74,7 +74,7 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
     }
 
     Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
-        Text("Pronađite poziciju ${skill}")
+        Text("Pronađite pozicije ${skill}")
 
 
         Row(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp), horizontalArrangement = Arrangement.SpaceBetween) {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchScreen.kt
@@ -49,12 +49,15 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider,skill: String) {
+fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider,skills: List<Int>) {
     val viewModel: WorkerSearchViewModel = viewModel()
     viewModel.tokenProvider.value = tokenProvider
     //Logika za dropdown meni
     /// Preporučeno je za manji broj opcija koristiti chip
-    viewModel.skill.value = skill
+    LaunchedEffect(Unit) {
+        viewModel.getAllSkills(skills)
+    }
+    var skill by viewModel.skill
     var isLoading by remember { mutableStateOf(true) }
     val isExpandedL by viewModel.isExpandedL
     val isExpandedR by viewModel.isExpandedR
@@ -212,5 +215,5 @@ fun WorkerSearchScreen(navController: NavController,tokenProvider: TokenProvider
 @Composable
 fun WorkerSearchScreenPreview() {
     val navController = rememberNavController()
-    WorkerSearchScreen(navController,tokenProvider = object : TokenProvider { override fun getToken(): String? { return null }},"")
+    WorkerSearchScreen(navController,tokenProvider = object : TokenProvider { override fun getToken(): String? { return null }},listOf(1,2))
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerSearchViewModel.kt
@@ -5,14 +5,16 @@ import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import hr.foi.air.baufind.service.SkillsService.SkillsService
 import hr.foi.air.baufind.service.WorkerService.WorkerSkillService
 import hr.foi.air.baufind.ws.model.Worker
+import hr.foi.air.baufind.ws.network.SkillService
 import hr.foi.air.baufind.ws.network.TokenProvider
 import hr.foi.air.baufind.ws.request.WorkersSkillBody
 
 
 class WorkerSearchViewModel() : ViewModel() {
-    val skill : MutableState<String> = mutableStateOf("")
+    val skill : MutableState<List<String>> = mutableStateOf(emptyList())
     val tokenProvider: MutableState<TokenProvider?> = mutableStateOf(null)
     val isExpandedL: MutableState<Boolean> = mutableStateOf(false)
     val isExpandedR: MutableState<Boolean> = mutableStateOf(false)
@@ -28,6 +30,17 @@ class WorkerSearchViewModel() : ViewModel() {
     val service = WorkerSkillService()
     val workers: MutableState<List<Worker>> = mutableStateOf(emptyList())
     val filteredWorkers: MutableState<List<Worker>> = mutableStateOf(emptyList())
+    val skillService = tokenProvider.value?.let { SkillsService(it) }
+    suspend fun getAllSkills (skills: List<Int>){
+        var _skills = skillService?.fetchAllSkills()
+        if (_skills != null) {
+            for (i in _skills){
+                if(skills.contains(i.id)){
+                    skill.value += i.title
+                }
+            }
+        }
+    }
     //Funkcija za filtriranje radnika
     fun updateFilteredWorkersL(option: String) {
         selectedItemL.value = option
@@ -50,7 +63,7 @@ class WorkerSearchViewModel() : ViewModel() {
     }
     suspend fun loadWorkers() {
         Log.e("tokenss", tokenProvider.value.toString())
-        workers.value =  service.getWorkersBySkill(workersSkillBody = WorkersSkillBody(skill.value),
+        workers.value =  service.getWorkersBySkill(workersSkillBody = WorkersSkillBody(skill.value.toString()),
             tokenProvider = tokenProvider.value!!)
         Log.e("getWorkersBySkill", workers.value.toString())
         filteredWorkers.value = workers.value

--- a/Software/Frontend/app/src/test/java/hr/foi/air/baufind/ExampleUnitTest.kt
+++ b/Software/Frontend/app/src/test/java/hr/foi/air/baufind/ExampleUnitTest.kt
@@ -1,5 +1,7 @@
 package hr.foi.air.baufind
 
+import hr.foi.air.baufind.ws.model.Skill
+import org.junit.Assert
 import org.junit.Test
 
 import org.junit.Assert.*
@@ -11,7 +13,24 @@ import org.junit.Assert.*
  */
 class ExampleUnitTest {
     @Test
-    fun addition_isCorrect() {
-
+     fun getAllSkills (){
+        val skill: MutableList<String> = mutableListOf()
+        var skills = listOf(1,2,3)
+        var _skills = listOf(
+            Skill(1, "Vodoinstalater"),
+            Skill(2, "Električar"),
+            Skill(3, "Moler"),
+            Skill(4, "Stolar"),
+            Skill(5, "Keramičar")
+        )
+        if (_skills != null) {
+            for (i in _skills){
+                if(skills.contains(i.id)){
+                    skill +=i.title
+                }
+            }
+        }
+        val result = skill.contains("Vodoinstalater") && skill.contains("Električar") && skill.contains("Moler")
+        Assert.assertTrue(result)
     }
 }


### PR DESCRIPTION
Riješen je hardkodiran vodoinstalater, sad ovaj ekran radi uz BAUF - 10 prosljeđujući listu pozicija za posao i s tim filtrirajući po toj listi.  PR BAUF -10 prilikom kreiranja posla javlja se 400 bad request ali zahtjev prolazi na backendu. Napisan je unit test za dobavljanje pozicija i filtriranje ih za daljnju obradu.
Promjenjena je navigacijska ikona i navigacijski elementi za dodavanje posla su dodani, sad se donji navigacijski alat vidi sa svih ekrana.
### Riješen BUG: Navigacija prekriva elemente ekrana 
- [+ ] 
![Snimka zaslona 2024-12-11 014224](https://github.com/user-attachments/assets/dbe66c43-43c0-4f35-8f1f-7c54e4b4c4be)
__________________________________________________
Potrebno je nakon ispravke BAUF - 10 testirati flow preko navigacijskih parametara
![Snimka zaslona 2024-12-11 012659](https://github.com/user-attachments/assets/e98d9d2f-e9ee-40e8-abb1-9bbaf48ae339)

Iz nepoznatog razloga zahtjev prolazi na backendu ali u android aplikaciji javlja bad request, testiranjem pomoću swaggera naslućujem da bi sve trebalo raditi ali to nije slučaj.
