### PR TITLE
BAUF-99-Popravak-povratne-poruke-za-dodavanje-posla

### DIFF
--- a/Software/Backend/WebApi/Controllers/JobController.cs
+++ b/Software/Backend/WebApi/Controllers/JobController.cs
@@ -30,13 +30,13 @@ public class JobController : ControllerBase
             });
         }
 
-        var job = _jobService.AddJob(request, userIdFromJwt.Value);
+        var response = _jobService.AddJob(request, userIdFromJwt.Value);
 
-        if (job.Error != null)
+        if (!string.IsNullOrEmpty(response.Error))
         {
-            return BadRequest(job);
+            return BadRequest(response);
         }
 
-        return job;
+        return response;
     }
 }


### PR DESCRIPTION
### Što je napravljeno
Popravljen bug da se na uspješno dodan posao vraća 400 Bad request. 
### Uzrok
Bug je nastao zbog jedne linije koda na backendu, a to je jer na uspješno dodavanje atribut success od response-a ima u sebi tekst, a atribut error je "" i ja sam provjeravao da je error != null, a "" je jednako null pa je stalno vraćalo BadRequest.
### Kako je popravljeno
Popravljeno tako što je provjera promijenjena u !string.IsNullOrEmpty(response.Error).
Istestirano je i radi kako treba.
### Dodatno
Također sam promijenio ime varijable u response jer se vraća samo tekst pa da ne izgleda po imenu kao da se vraća cijeli job koji je dodan.
