### PR TITLE
Bauf 94 pretra ivanje poslova po ulozi i imenu

### DIFF
--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/JobListItem.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/JobListItem.kt
@@ -2,6 +2,7 @@ package hr.foi.air.baufind.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,7 +29,8 @@ fun JobListItem(
             .clip(RoundedCornerShape(8.dp))
             .background(Color.LightGray)
             .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
-            .padding(8.dp),
+            .padding(8.dp)
+            .clickable { onItemClick() },
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ){

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobAddSkillsScreen.kt
@@ -75,8 +75,9 @@ fun JobAddSkillsScreen(navController: NavController, jobViewModel: JobViewModel,
                         if (!jobViewModel.jobPositions.any { it.name == skill.title }){
                             jobViewModel.jobPositions.add(JobPosition(skill.title, mutableIntStateOf(1), skill.id))
                             navController.popBackStack()
+                        }else{
+                            Toast.makeText(context, "Pozicija već postoji", Toast.LENGTH_SHORT).show()
                         }
-                        Toast.makeText(context, "Pozicija već postoji", Toast.LENGTH_SHORT).show()
                     }
                 )
             }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -139,6 +139,7 @@ fun JobPositionsLocationScreen(
                         if (response.added) {
                             var positions = gson.toJson(jobViewModel.getPositionsArray())
                             Log.d("ugbug12", "Position: $positions")
+                            jobViewModel.clearData()
                             navController.navigate("workersSearchScreen/${positions}")
                         } else {
                             Toast.makeText(context, response.message, Toast.LENGTH_LONG).show()

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobViewModel.kt
@@ -53,4 +53,15 @@ class JobViewModel : ViewModel(){
             List(jobPosition.count.value) { jobPosition.id }
         }
     }
+
+    fun clearData() {
+        jobName.value = ""
+        jobDescription.value = ""
+        allowInvitations.value = false
+        selectedImages.clear()
+        jobPositions.clear()
+        lat.doubleValue = 0.0
+        long.doubleValue = 0.0
+        location.value = ""
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
@@ -31,14 +31,18 @@ import hr.foi.air.baufind.ui.components.PrimaryTextField
 import hr.foi.air.baufind.ws.network.TokenProvider
 import kotlinx.coroutines.launch
 
-//moram za oba errora prikazat tako gdje bi bila lista poruku pogreške
-
 @Composable
 fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider){
     val coroutineScope = rememberCoroutineScope()
     var jobSearchResponse by remember { mutableStateOf<JobSearchResponse?>(null) }
 
     var searchText by remember { mutableStateOf("") }
+    val filteredJobs = remember(jobSearchResponse, searchText){
+        jobSearchResponse?.jobs?.filter { job ->
+            job.title.contains(searchText, ignoreCase = true) ||
+                    job.skills.any { skill -> skill.title.contains(searchText, ignoreCase = true)}
+        } ?: emptyList()
+    }
     val context = LocalContext.current
 
 
@@ -74,16 +78,11 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider){
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ){
-                jobSearchResponse?.jobs?.let { jobs ->
-                    items(jobs.size) { index ->
-                        val job = jobs[index]
-                        Log.d("JobSearchScreen poslovi", job.toString())
-                        JobListItem(
-                            job = job,
-                            onItemClick = {
-                                Toast.makeText(context, "Stisnut posao", Toast.LENGTH_SHORT).show()
-                            }
-                        )
+                items(filteredJobs.size) { index ->
+                    val job = filteredJobs[index]
+                    Log.d("JobSearchScreen poslovi", job.toString())
+                    JobListItem(job = job){
+                        Toast.makeText(context, "Otvoreno: " + job.title, Toast.LENGTH_SHORT).show()
                     }
                 }
             }


### PR DESCRIPTION
### Napravljeno
Napravljeno pretraživanje poslova po naslovu posla i imenima uloga tj. skillova koje posao traži.

Zamišljeno je da u popisu poslova korisnik može pretražiti npr "Keramičar" i dobiti će sve poslove koji odgovaraju za njegovu ulogu keramičara. To je jer ako ima npr 2 skilla a neki posao traži 1 od ta dva, onda će ovo prikazati samo poslove koji imaju taj 1 kojeg želi tj. maknut će poslove koji su mu prikazani zbog drugog skilla kojeg u tom trenutku ne želi. 

Moglo se i neki dropdown kao alternativa ali u skicama je ovako zamišljeno.
### Popravljeni bugovi

- Popravio sam bug gdje ViewModel ostane popunjen nakon kreiranja novog posla
- Popravio sam one line bug gdje bi se pri dodavanju novog skilla poslu stalno pokazivao Toast message da već postoji, a ne postoji

### Known problemi
Inicijalno učitavanje popisa sa API-a je prilično sporo, neko rješenje bi bilo neko straničenje ili slično na backendu ali to je pre kompleksno za sad, možda sljedeći sprint.

Dodao sam ovaj problem u Confluence bug tablicu
