### PR TITLE
Bauf 96 prikaz podataka posla

### DIFF
--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -66,7 +66,8 @@ class MainActivity : ComponentActivity() {
                                 "jobAddSkillsScreen",
                                 "jobDetailsScreen",
                                 "myUserProfileScreen",
-                                "jobSearchScreen"
+                                "jobSearchScreen",
+                                "jobSearchDetailsScreen"
                             )) {
                             BottomNavigationBar(navController = navController)
                         }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -28,7 +28,9 @@ import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobAddSkillsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobPositionsLocationScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobViewModel
+import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchDetailsScreen
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchScreen
+import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchViewModel
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.EditProfileScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.UserProfileViewModel
@@ -49,8 +51,9 @@ class MainActivity : ComponentActivity() {
         val jwtToken = sharedPreferences.getString("jwt_token", null)
         val userProfileViewModel = UserProfileViewModel(tokenProvider)
         val gson: Gson = Gson()
+        val jobViewModel = JobViewModel()
+        val jobSearchViewModel = JobSearchViewModel()
         setContent {
-            val jobViewModel : JobViewModel = viewModel()
             val navController = rememberNavController()
             val currentRoute = navController
                 .currentBackStackEntryAsState().value?.destination?.route
@@ -104,7 +107,8 @@ class MainActivity : ComponentActivity() {
                             composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController, jobViewModel, tokenProvider, mapProvider) }
                             composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel, tokenProvider) }
 
-                            composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider) }
+                            composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider, jobSearchViewModel) }
+                            composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchViewModel) }
 
                         }
                     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/helpers/PictureHelper.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/helpers/PictureHelper.kt
@@ -1,0 +1,15 @@
+package hr.foi.air.baufind.helpers
+
+class PictureHelper{
+    companion object{
+        fun decodeBase64ToByteArray(base64: String?): ByteArray? {
+            return base64?.let {
+                try {
+                    android.util.Base64.decode(it, android.util.Base64.DEFAULT)
+                } catch (e: IllegalArgumentException) {
+                    null
+                }
+            }
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/DisplayTextField.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/DisplayTextField.kt
@@ -1,6 +1,7 @@
 package hr.foi.air.baufind.ui.components
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -33,7 +34,9 @@ fun DisplayTextField(
                 disabledContainerColor = MaterialTheme.colorScheme.primaryContainer,
                 disabledTextColor = MaterialTheme.colorScheme.onSurface
             ),
-            modifier = Modifier.padding(top = 4.dp)
+            modifier = Modifier
+                .padding(top = 4.dp)
+                .fillMaxWidth()
         )
     }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/DisplayTextField.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/DisplayTextField.kt
@@ -1,0 +1,39 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DisplayTextField(
+    title : String,
+    text : String,
+    modifier: Modifier = Modifier
+){
+    Column(modifier = modifier){
+        Text(
+            text = title,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        TextField(
+            value = text,
+            onValueChange = {},
+            readOnly = true,
+            enabled = false,
+            colors = TextFieldDefaults.colors(
+                unfocusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                focusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                disabledContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                disabledTextColor = MaterialTheme.colorScheme.onSurface
+            ),
+            modifier = Modifier.padding(top = 4.dp)
+        )
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -1,0 +1,8 @@
+package hr.foi.air.baufind.ui.screens.JobSearchScreen
+
+import androidx.navigation.NavController
+import hr.foi.air.baufind.ws.network.TokenProvider
+
+fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel){
+
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -1,11 +1,18 @@
 package hr.foi.air.baufind.ui.screens.JobSearchScreen
 
+import android.graphics.BitmapFactory
 import android.util.Log
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -15,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -26,18 +34,18 @@ import hr.foi.air.baufind.navigation.IconType
 import hr.foi.air.baufind.ui.components.DisplayTextField
 import hr.foi.air.baufind.ui.components.PrimaryButton
 import hr.foi.air.baufind.ui.components.PrimaryTextField
+import hr.foi.air.baufind.ui.screens.UserProfileScreen.decodeBase64ToByteArray
 import hr.foi.air.baufind.ws.network.TokenProvider
 
 @Composable
 fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel){
     val selectedJob = jobSearchViewModel.selectedJob.value
-    Log.d("JobSearchDetailsScreen", "Selected job: $selectedJob")
 
     val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(22.dp,0.dp)
+            .padding(22.dp, 0.dp)
             .verticalScroll(scrollState),
         horizontalAlignment = Alignment.CenterHorizontally
     ){
@@ -62,7 +70,27 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold
             )
-            //tu idu fotografije
+            Spacer(modifier = Modifier.height(24.dp))
+            LazyRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+            ){
+                items(selectedJob.pictures) { base64Image ->
+                    val imageData = decodeBase64ToByteArray(base64Image)
+                    val bitmap = imageData?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
+
+                    if (bitmap != null) {
+                        Image(
+                            bitmap = bitmap.asImageBitmap(),
+                            contentDescription = "Slika posla",
+                            modifier = Modifier
+                                .size(200.dp)
+                                .padding(8.dp)
+                        )
+                    }
+                }
+            }
 
             Spacer(modifier = Modifier.height(24.dp))
             PrimaryButton(

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -1,8 +1,83 @@
 package hr.foi.air.baufind.ui.screens.JobSearchScreen
 
+import android.util.Log
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import hr.foi.air.baufind.R
+import hr.foi.air.baufind.navigation.IconType
+import hr.foi.air.baufind.ui.components.DisplayTextField
+import hr.foi.air.baufind.ui.components.PrimaryButton
+import hr.foi.air.baufind.ui.components.PrimaryTextField
 import hr.foi.air.baufind.ws.network.TokenProvider
 
+@Composable
 fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel){
+    val selectedJob = jobSearchViewModel.selectedJob.value
+    Log.d("JobSearchDetailsScreen", "Selected job: $selectedJob")
 
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(22.dp,0.dp)
+            .verticalScroll(scrollState),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ){
+        if (selectedJob != null) {
+            Log.d("JobSearchDetailsScreen", "Selected job unutar ifa: $selectedJob")
+            Spacer(modifier = Modifier.height(24.dp))
+            DisplayTextField(title = "Naslov posla", text = selectedJob.title)
+            Spacer(modifier = Modifier.height(24.dp))
+            DisplayTextField(title = "Opis posla", text = selectedJob.description)
+            Spacer(modifier = Modifier.height(24.dp))
+            DisplayTextField(title = "Lokacija posla", text = selectedJob.location)
+            Spacer(modifier = Modifier.height(24.dp))
+            PrimaryButton(
+                text = "Profil poslodavca",
+                icon = Icons.Default.Person,
+                onClick = {}
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = "Fotografije",
+                modifier = Modifier.align(Alignment.Start),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            //tu idu fotografije
+
+            Spacer(modifier = Modifier.height(24.dp))
+            PrimaryButton(
+                text = "Pridruži se poslu",
+                icon = Icons.Default.Add,
+                onClick = {}
+            )
+        }
+    }
 }
+
+@Preview(showBackground = true)
+@Composable
+fun JobSearchDetailsScreenPreview() {
+    val navController = rememberNavController()
+    JobSearchDetailsScreen(navController, tokenProvider = object : TokenProvider { override fun getToken(): String? { return null } }, jobSearchViewModel = JobSearchViewModel())
+}
+

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -3,6 +3,7 @@ package hr.foi.air.baufind.ui.screens.JobSearchScreen
 import android.graphics.BitmapFactory
 import android.util.Log
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -20,6 +22,10 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
@@ -40,6 +46,8 @@ import hr.foi.air.baufind.ws.network.TokenProvider
 @Composable
 fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel){
     val selectedJob = jobSearchViewModel.selectedJob.value
+
+    var selectedImageIndex by remember { mutableStateOf<Int?>(null) }
 
     val scrollState = rememberScrollState()
     Column(
@@ -76,17 +84,21 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp)
             ){
-                items(selectedJob.pictures) { base64Image ->
+                itemsIndexed(selectedJob.pictures) { index, base64Image ->
                     val imageData = PictureHelper.decodeBase64ToByteArray(base64Image)
                     val bitmap = imageData?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
 
                     if (bitmap != null) {
+                        val imageSize = if(selectedImageIndex == index) 400.dp else 200.dp
                         Image(
                             bitmap = bitmap.asImageBitmap(),
                             contentDescription = "Slika posla",
                             modifier = Modifier
-                                .size(200.dp)
+                                .size(imageSize)
                                 .padding(8.dp)
+                                .clickable{
+                                    selectedImageIndex = if(selectedImageIndex == index) null else index
+                                }
                         )
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -61,7 +61,7 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
             PrimaryButton(
                 text = "Profil poslodavca",
                 icon = Icons.Default.Person,
-                onClick = {}
+                onClick = { /*ide na profil poslodavca*/}
             )
             Spacer(modifier = Modifier.height(24.dp))
             Text(
@@ -96,7 +96,11 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
             PrimaryButton(
                 text = "Pridruži se poslu",
                 icon = Icons.Default.Add,
-                onClick = {}
+                onClick = {
+                    //salje zahtjev za pridruzenje poslu
+                    //jobSearchViewModel.clearData()
+                    //navController.navigate()
+                }
             )
         }
     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -30,11 +30,11 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.R
+import hr.foi.air.baufind.helpers.PictureHelper
 import hr.foi.air.baufind.navigation.IconType
 import hr.foi.air.baufind.ui.components.DisplayTextField
 import hr.foi.air.baufind.ui.components.PrimaryButton
 import hr.foi.air.baufind.ui.components.PrimaryTextField
-import hr.foi.air.baufind.ui.screens.UserProfileScreen.decodeBase64ToByteArray
 import hr.foi.air.baufind.ws.network.TokenProvider
 
 @Composable
@@ -77,7 +77,7 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
                     .padding(horizontal = 16.dp)
             ){
                 items(selectedJob.pictures) { base64Image ->
-                    val imageData = decodeBase64ToByteArray(base64Image)
+                    val imageData = PictureHelper.decodeBase64ToByteArray(base64Image)
                     val bitmap = imageData?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
 
                     if (bitmap != null) {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
@@ -65,12 +65,9 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider){
             modifier = Modifier.fillMaxWidth(),
             isError = false
         )
-        //ako je empty i message empty onda znaci da nije jos ucitao
-        //ako je empty a ima message onda je error
-        //ako nije empty onda ucitavaj
-        if(jobSearchViewModel.jobs.value.isEmpty() && jobSearchViewModel.message == null){
+        if(jobSearchViewModel.isLoading()){
             Text(text = "Učitavam...")
-        }else if(jobSearchViewModel.jobs.value.isEmpty() && jobSearchViewModel.message != null){
+        }else if(jobSearchViewModel.hasError()){
             Text(text = jobSearchViewModel.message!!)
         }
         else{

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
@@ -33,7 +33,7 @@ import hr.foi.air.baufind.ws.network.TokenProvider
 import kotlinx.coroutines.launch
 
 @Composable
-fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider){
+fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel){
 
     val jobSearchViewModel : JobSearchViewModel = viewModel()
     LaunchedEffect(Unit){
@@ -83,7 +83,7 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider){
                     Log.d("JobSearchScreen poslovi", job.toString())
                     JobListItem(job = job){
                         jobSearchViewModel.selectedJob.value = job
-                        Toast.makeText(context, "Selected job: " + jobSearchViewModel.selectedJob.value?.title, Toast.LENGTH_SHORT).show()
+                        navController.navigate("jobSearchDetailsScreen")
                     }
                 }
             }
@@ -95,5 +95,5 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider){
 @Composable
 fun JobSearchScreenPreview() {
     val navController = rememberNavController()
-    JobSearchScreen(navController, tokenProvider = object : TokenProvider { override fun getToken(): String? { return null } })
+    JobSearchScreen(navController, tokenProvider = object : TokenProvider { override fun getToken(): String? { return null } }, jobSearchViewModel = JobSearchViewModel())
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel){
     LaunchedEffect(Unit){
+        jobSearchViewModel.clearData()
         jobSearchViewModel.tokenProvider = tokenProvider
     }
 
@@ -46,7 +47,6 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, 
                     job.skills.any { skill -> skill.title.contains(searchText, ignoreCase = true)}
         }
     }
-    val context = LocalContext.current
 
 
     Column(

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
@@ -34,8 +34,6 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel){
-
-    val jobSearchViewModel : JobSearchViewModel = viewModel()
     LaunchedEffect(Unit){
         jobSearchViewModel.tokenProvider = tokenProvider
     }
@@ -80,7 +78,6 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, 
             ){
                 items(filteredJobs.size) { index ->
                     val job = filteredJobs[index]
-                    Log.d("JobSearchScreen poslovi", job.toString())
                     JobListItem(job = job){
                         jobSearchViewModel.selectedJob.value = job
                         navController.navigate("jobSearchDetailsScreen")

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
@@ -32,4 +32,12 @@ class JobSearchViewModel : ViewModel(){
             jobs.value = response.jobs
         }
     }
+
+    fun isLoading() : Boolean{
+        return jobs.value.isEmpty() && message == null
+    }
+
+    fun hasError() : Boolean{
+        return jobs.value.isEmpty() && message != null
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
@@ -1,0 +1,35 @@
+package hr.foi.air.baufind.ui.screens.JobSearchScreen
+
+import android.util.Log
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import hr.foi.air.baufind.service.JobSearchService.JobSearchResponse
+import hr.foi.air.baufind.service.JobSearchService.JobSearchService
+import hr.foi.air.baufind.ws.model.JobSearchModel
+import hr.foi.air.baufind.ws.network.TokenProvider
+import kotlinx.coroutines.launch
+
+class JobSearchViewModel : ViewModel(){
+    var success : Boolean = false
+    var message : String? = null
+    val jobs = mutableStateOf(emptyList<JobSearchModel>())
+    val selectedJob = mutableStateOf<JobSearchModel?>(null)
+
+    var tokenProvider: TokenProvider? = null
+    set(value) {
+        field = value
+        value?.let { loadJobs(it) }
+    }
+
+    private fun loadJobs(tokenProvider: TokenProvider) {
+        viewModelScope.launch {
+            val service = JobSearchService()
+            val response : JobSearchResponse = service.fetchJobsForCurrentUserAsync(tokenProvider)
+            Log.d("JobSearchViewModel", "Response: $response")
+            success = response.success
+            message = response.message
+            jobs.value = response.jobs
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
@@ -14,7 +14,7 @@ class JobSearchViewModel : ViewModel(){
     var success : Boolean = false
     var message : String? = null
     val jobs = mutableStateOf(emptyList<JobSearchModel>())
-    val selectedJob = mutableStateOf<JobSearchModel?>(null)
+    var selectedJob = mutableStateOf<JobSearchModel?>(null)
 
     var tokenProvider: TokenProvider? = null
     set(value) {
@@ -31,6 +31,10 @@ class JobSearchViewModel : ViewModel(){
             message = response.message
             jobs.value = response.jobs
         }
+    }
+
+    fun clearData(){
+        selectedJob = mutableStateOf(null)
     }
 
     fun isLoading() : Boolean{

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/UserProfileScreen/ReviewsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/UserProfileScreen/ReviewsScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.navigation.NavController
+import hr.foi.air.baufind.helpers.PictureHelper
 import hr.foi.air.baufind.service.ReviewService.ReviewService
 import hr.foi.air.baufind.ws.model.Review
 import hr.foi.air.baufind.ws.network.TokenProvider
@@ -259,7 +260,7 @@ fun ReviewItem(review: Review) {
                 .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f), CircleShape)
         ) {
-            val imageData = review.reviewerImage?.let { decodeBase64ToByteArray(it) }
+            val imageData = review.reviewerImage?.let { PictureHelper.decodeBase64ToByteArray(it) }
             val bitmap = imageData?.let { BitmapFactory.decodeByteArray(it, 0, it.size) }
 
             if (bitmap != null) {
@@ -352,7 +353,7 @@ fun ReviewItem(review: Review) {
                         val endIndex = (startIndex + 5).coerceAtMost(review.pictures.size)
 
                         items(review.pictures.subList(startIndex, endIndex)) { picture ->
-                            val decodedBytes = decodeBase64ToByteArray(picture.picture)
+                            val decodedBytes = PictureHelper.decodeBase64ToByteArray(picture.picture)
 
                             val imageBitmap = decodedBytes?.let {
                                 BitmapFactory.decodeByteArray(it, 0, it.size).asImageBitmap()

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/UserProfileScreen/UserProfileScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/UserProfileScreen/UserProfileScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import hr.foi.air.baufind.helpers.PictureHelper
 import hr.foi.air.baufind.service.UserProfileService.UserProfileService
 import hr.foi.air.baufind.service.jwtService.JwtService
 import hr.foi.air.baufind.ui.components.Skill
@@ -75,15 +76,6 @@ fun EditProfileButton(onClick: () -> Unit) {
                 text = "Edit Profile",
                 style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
             )
-        }
-    }
-}
-fun decodeBase64ToByteArray(base64: String?): ByteArray? {
-    return base64?.let {
-        try {
-            android.util.Base64.decode(it, android.util.Base64.DEFAULT)
-        } catch (e: IllegalArgumentException) {
-            null
         }
     }
 }
@@ -220,7 +212,7 @@ fun userProfileScreen(
                     .background(MaterialTheme.colorScheme.background)
                     .verticalScroll(rememberScrollState())
             ) {
-                UserProfileHeader(profile.name, profile.address ?: "N/A", decodeBase64ToByteArray(profile.profilePicture))
+                UserProfileHeader(profile.name, profile.address ?: "N/A", PictureHelper.decodeBase64ToByteArray(profile.profilePicture))
                 EditProfileButton(onClick = {navController.navigate("editUserProfileScreen")})
                 UserProfileContactInformation(profile.address ?: "N/A", profile.phone ?: "N/A", profile.email)
                 UserSkillSection(profile.skills.orEmpty().map { skill -> Skill(skill.id, skill.title) })


### PR DESCRIPTION
## Što je napravljeno

1. Napravljen je ekran za pregled detalja o poslu kojeg smo našli pretraživanjem, ima i scroll. Ekran je sljedeći:

![image](https://github.com/user-attachments/assets/e4dbf3ed-3228-477e-ac9e-27b2a41142fc)

2. Napravljena je poruka na ekranu za pretraživanje poslova kada se učitavaju podatci da nije samo prazan ekran

![image](https://github.com/user-attachments/assets/44a1c20d-d048-44a8-bd19-00ce18af7223)

4. Napravio sam i da se slike mogu povećati kada se pritisnu

![image](https://github.com/user-attachments/assets/ff09bff9-a5f1-4f9d-b2d5-0b2a1d564d02)

6. Stvorio sam novu PictureHelper klasu u koju sam stavio jednu zajedničku funkciju meni i @mvujica21. U budućnosti bi mogli u potpunosti refaktorirati sve oko uploadanja i prikazivanja slika u tu klasu, zasad je samo jedna funkcija

![image](https://github.com/user-attachments/assets/967a2ad0-6590-420e-b27c-e0e7633a1171)

7. U skladu sa prošlim PR-om, refaktorirao sam način kako dohvaćam podatke za popis poslova i stvorio ViewModel za JobSearch koji se zove JobSearchViewModel. U njemu se nalazi funkcija loadJobs koja dohvaća sa API-a preko service klase popis poslova, i ima atribute od kojih je i selectedJob jer je to potrebno u sljedećem ekranu.
8. 
![image](https://github.com/user-attachments/assets/b1d75c83-af92-4f5a-9e5b-a83021dd117b)

Sada je kod na frontendu puno lakši za čitati:

![image](https://github.com/user-attachments/assets/e2929eb4-800d-42f7-98a9-623c9887d54c)

## Što je sljedeće

@dmatijani @mvujica21 vi sada imate ekran na kojem možete dovršiti svoje.

Za mene je slanje zahtjeva za pridruživanje sljedeći korak ali to će morati bit neki kratki sastanak da shvatim kako smo to zamislili točno.

