### PR TITLE
Bauf 88 pregled tudih korisnickih profila

### DIFF
--- a/Software/Backend/WebApi/Controllers/UserController.cs
+++ b/Software/Backend/WebApi/Controllers/UserController.cs
@@ -128,7 +128,7 @@ public class UserController : ControllerBase
     }
 
     // GET: /users/profile/{id}
-    [HttpGet("/profile/{id}")]
+    [HttpGet("profile/{id}")]
     [Authorize]
     public ActionResult<UserProfileResponse> GetUserProfile(int id)
     {

--- a/Software/Backend/WebApi/Controllers/UserController.cs
+++ b/Software/Backend/WebApi/Controllers/UserController.cs
@@ -127,17 +127,27 @@ public class UserController : ControllerBase
 
     }
 
-    /*  // GET: /users/profile/{id}
-      [HttpGet("/profile/{id}")]
-      public ActionResult<UserProfileResponse> GetUserProfile(int id)
-      {
-          var userProfileData = _userService.GetUserProfileData(id);
-          if (userProfileData.userProfileModel == null)
-          {
-              return NotFound(userProfileData);
-          }
-          return userProfileData;
-      }*/
+    // GET: /users/profile/{id}
+    [HttpGet("/profile/{id}")]
+    [Authorize]
+    public ActionResult<UserProfileResponse> GetUserProfile(int id)
+    {
+        var userIdFromJwt = HttpContext.Items["UserId"] as int?;
+
+        if (!userIdFromJwt.HasValue) 
+        {
+            return Unauthorized(new UserProfileResponse()
+            {
+                Error = "Ne možete pristupiti tom resursu!"
+            });
+        }
+        var userProfileData = _userService.GetUserProfileData(id);
+        if (userProfileData.userProfileModel == null)
+        {
+            return NotFound(userProfileData);
+        }
+        return userProfileData;
+    }
 
     // POST: /users/login
     [HttpPost("login")]

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
@@ -26,7 +26,7 @@ fun BottomNavigationBar(navController: NavController) {
             route = "jobSearchScreen",
             icon = IconType.Vector(imageVector = Icons.Default.Search), label = "Search jobs"),
             BottomNavItem(
-            route = "myUserProfileScreen",
+            route = "userProfileScreen",
             icon = IconType.Vector(imageVector = Icons.Default.Person), label = "Profile"),
 
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/UserProfileService/UserProfileService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/UserProfileService/UserProfileService.kt
@@ -44,5 +44,22 @@ class UserProfileService(tokenProvider: TokenProvider){
             null
         }
     }
+    suspend fun getUserProfileById(id: Int?): UserProfileResponse? {
+        return try {
+            val wrapper = id?.let { userProfileNetworkService.getUserProfileById(it) }
+            if (wrapper?.error.isNullOrEmpty()) {
+                wrapper?.userProfileModel
+            } else {
+                println("Error from backend: ${wrapper?.error}")
+                null
+            }
+        } catch (e: HttpException) {
+            e.printStackTrace()
+            null
+        } catch (e: IOException) {
+            e.printStackTrace()
+            null
+        }
+    }
 
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -43,7 +43,7 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
     val selectedJob = jobSearchViewModel.selectedJob.value
 
     var selectedImageIndex by remember { mutableStateOf<Int?>(null) }
-    val employerId = selectedJob?.employerId
+    val employerId = selectedJob?.employer_id
     val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
@@ -61,7 +61,6 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
             Spacer(modifier = Modifier.height(24.dp))
             DisplayTextField(title = "Lokacija posla", text = selectedJob.location)
             Spacer(modifier = Modifier.height(24.dp))
-            Log.d("USERIDDDDDD", selectedJob.toString())
 
             PrimaryButton(
                 text = "Profil poslodavca",

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -5,7 +5,6 @@ import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,7 +12,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -35,12 +33,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
-import hr.foi.air.baufind.R
 import hr.foi.air.baufind.helpers.PictureHelper
-import hr.foi.air.baufind.navigation.IconType
 import hr.foi.air.baufind.ui.components.DisplayTextField
 import hr.foi.air.baufind.ui.components.PrimaryButton
-import hr.foi.air.baufind.ui.components.PrimaryTextField
 import hr.foi.air.baufind.ws.network.TokenProvider
 
 @Composable
@@ -48,7 +43,7 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
     val selectedJob = jobSearchViewModel.selectedJob.value
 
     var selectedImageIndex by remember { mutableStateOf<Int?>(null) }
-
+    val employerId = selectedJob?.employerId
     val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
@@ -66,10 +61,13 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
             Spacer(modifier = Modifier.height(24.dp))
             DisplayTextField(title = "Lokacija posla", text = selectedJob.location)
             Spacer(modifier = Modifier.height(24.dp))
+            Log.d("USERIDDDDDD", selectedJob.toString())
+
             PrimaryButton(
                 text = "Profil poslodavca",
                 icon = Icons.Default.Person,
-                onClick = { /*ide na profil poslodavca*/}
+                onClick = { navController.navigate("userProfileScreen?userId=$employerId")
+                }
             )
             Spacer(modifier = Modifier.height(24.dp))
             Text(

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/LoginScreen/LoginScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/LoginScreen/LoginScreen.kt
@@ -129,7 +129,10 @@ fun LoginScreen(navController: NavController, context : Context, tokenProvider: 
                         )
                         if (response.successfulLogin){
                             JwtService.saveJwt(context, response.jwt)
-                            navController.navigate("jobDetailsScreen")
+                            navController.navigate("jobDetailsScreen") {
+                                popUpTo("login") { inclusive = true }
+                            }
+
                         }
                         else {
                             email = ""

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/JobSearchModel.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/JobSearchModel.kt
@@ -2,11 +2,11 @@ package hr.foi.air.baufind.ws.model
 
 data class JobSearchModel(
     val id: Int,
-    val employerId: Int,
-    val jobStatusId: Int,
+    val employer_id: Int,
+    val job_status_id: Int,
     val title: String,
     val description: String,
-    val allowWorkerInvite: Boolean,
+    val allow_worker_invite: Boolean,
     val location: String,
     val lat: Double?,
     val lng: Double?,

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/UserProfileService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/UserProfileService.kt
@@ -7,6 +7,7 @@ import hr.foi.air.baufind.ws.response.UserProfileWrapper
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PUT
+import retrofit2.http.Path
 
 interface UserProfileService {
     @GET("users/profile")
@@ -15,4 +16,6 @@ interface UserProfileService {
     suspend fun updateUserProfile(@Body request: UpdateUserRequest): UpdateUserResponse
     @GET("users/delete")
     suspend fun deleteUser(): DeleteUserResponse
+    @GET("users/profile/{id}")
+    suspend fun getUserProfileById(@Path("id") id: Int): UserProfileWrapper
 }


### PR DESCRIPTION
Ovaj PR je riješio prikaz tuđih korisničkih profila. Nije ništa komplicirano, ukratko objasnim.

### **Backend:**
Za prikaz vlastitog profila koristio se poziv na backend "GetUserProfile" koji ne prima nikakve argumente, nego samo iz JWT izvuće korisnika. Sada sam samo kreirao poziv GetUserProfileById koji je identičan, samo na drugoj putanji i koristi ID kao argument. Znači servis u repozitorij nepromijenjen, koriste isti, samo što se šalje drugi ID.

### **Frontend:**
UserProfileScreen je samo trebalo malo prilagoditi. Dodao sam kao parametar userId i samo provjeravam je li userId -1 ili neki konkretan. Ako je userId == -1 tada znači da je vlastiti profil ( ne šaljem znači konkretan id kao argument), a ako je neki normalan broj tada šaljem id. Rezultat te provjere ovisi koji će se upit pozvati. I također uz to ovisno je li userId normalan argument ovisi hoće li se prikazati još neke stvari na profilu poput gumba za EditProfil i odjave.
Na Viktorovm ekranu sam dodam da samo nakon odabira posla, i klikom na profil poslodavca da se šalje taj emplyoerId.

Također riješio sam i bugfix, da kada kliknem nazad dok sam na profilu vodi na login. Samo sam nakon prijave kada se prebaci ja prvi zaslon iz stoga izbacio ekran prijave. 