### PR TITLE
Bauf 81 implementacija prikaza lokacije preko karte

### DIFF
--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
         GoogleMapProvider(),
         OpenStreetMapProvider()
     ) // TODO: ubaciti module pomoću refleksije (a ne ručno)
-    private val mapProvider = mapProviders[2] // TODO: da se može odabrati u postavkama
+    private val mapProvider = mapProviders[0] // TODO: da se može odabrati u postavkama
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -42,9 +42,6 @@ import hr.foi.air.baufind.ui.theme.BaufindTheme
 import hr.foi.air.baufind.ws.network.AppTokenProvider
 
 class MainActivity : ComponentActivity() {
-    private val mapProviders = MapHelper.discoverMapProviders()
-    private val mapProvider = mapProviders[0] // TODO: da se može odabrati u postavkama
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val sharedPreferences = getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
@@ -129,11 +126,11 @@ class MainActivity : ComponentActivity() {
                                 WorkerSearchScreen(navController,tokenProvider,deserializedList)
                             }
                             composable("jobDetailsScreen") { JobDetailsScreen(navController, jobViewModel) }
-                            composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController, jobViewModel, tokenProvider, mapProvider) }
+                            composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController, jobViewModel, tokenProvider) }
                             composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel, tokenProvider) }
 
                             composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider, jobSearchViewModel) }
-                            composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchViewModel, mapProvider) }
+                            composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchViewModel) }
 
                         }
                     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
         GoogleMapProvider(),
         OpenStreetMapProvider()
     ) // TODO: ubaciti module pomoću refleksije (a ne ručno)
-    private val mapProvider = mapProviders[0] // TODO: da se može odabrati u postavkama
+    private val mapProvider = mapProviders[2] // TODO: da se može odabrati u postavkama
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -136,7 +136,7 @@ class MainActivity : ComponentActivity() {
                             composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel, tokenProvider) }
 
                             composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider, jobSearchViewModel) }
-                            composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchViewModel) }
+                            composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchViewModel, mapProvider) }
 
                         }
                     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -22,6 +22,7 @@ import com.google.gson.Gson
 import hr.foi.air.baufind.core.map.MapProvider
 import hr.foi.air.baufind.example_map.ExampleMapProvider
 import hr.foi.air.baufind.google_map.GoogleMapProvider
+import hr.foi.air.baufind.helpers.MapHelper
 import hr.foi.air.baufind.navigation.BottomNavigationBar
 import hr.foi.air.baufind.open_street_map.OpenStreetMapProvider
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobAddSkillsScreen
@@ -41,11 +42,7 @@ import hr.foi.air.baufind.ui.theme.BaufindTheme
 import hr.foi.air.baufind.ws.network.AppTokenProvider
 
 class MainActivity : ComponentActivity() {
-    private val mapProviders: List<MapProvider> = listOf(
-        ExampleMapProvider(),
-        GoogleMapProvider(),
-        OpenStreetMapProvider()
-    ) // TODO: ubaciti module pomoću refleksije (a ne ručno)
+    private val mapProviders = MapHelper.discoverMapProviders()
     private val mapProvider = mapProviders[0] // TODO: da se može odabrati u postavkama
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -33,6 +33,7 @@ import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchDetailsScreen
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchScreen
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchViewModel
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
+import hr.foi.air.baufind.ui.screens.Settings.SettingsScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.EditProfileScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.ReviewsScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.UserProfileViewModel
@@ -65,7 +66,8 @@ class MainActivity : ComponentActivity() {
                                 "jobAddSkillsScreen",
                                 "jobDetailsScreen",
                                 "jobSearchScreen",
-                                "jobSearchDetailsScreen"
+                                "jobSearchDetailsScreen",
+                                "settingsScreen"
                             )
                         ) {
                             BottomNavigationBar(navController = navController)
@@ -131,6 +133,7 @@ class MainActivity : ComponentActivity() {
 
                             composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider, jobSearchViewModel) }
                             composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchViewModel) }
+                            composable("settingsScreen") { SettingsScreen(navController) }
 
                         }
                     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/helpers/MapHelper.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/helpers/MapHelper.kt
@@ -8,7 +8,7 @@ import hr.foi.air.baufind.open_street_map.OpenStreetMapProvider
 class MapHelper {
     companion object {
         val mapProviders = discoverMapProviders()
-        var mapProvider: MapProvider = mapProviders[1]
+        var mapProvider: MapProvider = mapProviders[2]
 
         private fun discoverMapProviders(): List<MapProvider> {
             val mapProviders = mutableListOf<MapProvider>()

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/helpers/MapHelper.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/helpers/MapHelper.kt
@@ -7,7 +7,10 @@ import hr.foi.air.baufind.open_street_map.OpenStreetMapProvider
 
 class MapHelper {
     companion object {
-        fun discoverMapProviders(): List<MapProvider> {
+        val mapProviders = discoverMapProviders()
+        var mapProvider: MapProvider = mapProviders[1]
+
+        private fun discoverMapProviders(): List<MapProvider> {
             val mapProviders = mutableListOf<MapProvider>()
 
             mapProviders.add(ExampleMapProvider())

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/helpers/MapHelper.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/helpers/MapHelper.kt
@@ -1,0 +1,20 @@
+package hr.foi.air.baufind.helpers
+
+import hr.foi.air.baufind.core.map.MapProvider
+import hr.foi.air.baufind.example_map.ExampleMapProvider
+import hr.foi.air.baufind.google_map.GoogleMapProvider
+import hr.foi.air.baufind.open_street_map.OpenStreetMapProvider
+
+class MapHelper {
+    companion object {
+        fun discoverMapProviders(): List<MapProvider> {
+            val mapProviders = mutableListOf<MapProvider>()
+
+            mapProviders.add(ExampleMapProvider())
+            mapProviders.add(GoogleMapProvider())
+            mapProviders.add(OpenStreetMapProvider())
+
+            return mapProviders
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/ExpandableText.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/ExpandableText.kt
@@ -1,0 +1,30 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+
+@Composable
+fun ExpandableText(
+    modifier: Modifier,
+    overflow: TextOverflow = TextOverflow.Ellipsis,
+    text: String = ""
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Text(
+        text = text,
+        overflow = overflow,
+        maxLines = if (expanded) Int.MAX_VALUE else 1,
+        modifier = modifier
+            .clickable { expanded = !expanded }
+            .animateContentSize()
+    )
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -30,6 +30,7 @@ import com.google.gson.Gson
 import hr.foi.air.baufind.R
 import hr.foi.air.baufind.core.map.MapProvider
 import hr.foi.air.baufind.core.map.models.Coordinates
+import hr.foi.air.baufind.helpers.MapHelper
 import hr.foi.air.baufind.service.JobService.JobDao
 import hr.foi.air.baufind.service.JobService.JobService
 import hr.foi.air.baufind.ui.components.ExpandableText
@@ -44,8 +45,7 @@ import kotlinx.coroutines.launch
 fun JobPositionsLocationScreen(
     navController: NavController,
     jobViewModel: JobViewModel,
-    tokenProvider: TokenProvider,
-    mapProvider: MapProvider
+    tokenProvider: TokenProvider
 ){
     jobViewModel.tokenProvider.value = tokenProvider
     val coroutineScope = rememberCoroutineScope()
@@ -135,7 +135,7 @@ fun JobPositionsLocationScreen(
             fontWeight = FontWeight.Bold
         )
         Spacer(modifier = Modifier.height(24.dp))
-        mapProvider.LocationPickerMapScreen(
+        MapHelper.mapProvider.LocationPickerMapScreen(
             modifier = Modifier,
             coordinates = coordinates.value,
             onCoordinatesChanged = { loc ->
@@ -212,21 +212,6 @@ fun JobPositionsLocationScreenPreview() {
     JobPositionsLocationScreen(
         navController,
         JobViewModel(),
-        object : TokenProvider { override fun getToken(): String? { return null } },
-        object : MapProvider {
-            @Composable
-            override fun LocationPickerMapScreen(
-                modifier: Modifier,
-                coordinates: Coordinates,
-                onCoordinatesChanged: (Coordinates) -> Unit
-            ) { }
-
-            @Composable
-            override fun LocationShowMapScreen(
-                modifier: Modifier,
-                coordinates: Coordinates,
-                location: String
-            ) { }
-        }
+        object : TokenProvider { override fun getToken(): String? { return null } }
     )
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -1,8 +1,6 @@
 package hr.foi.air.baufind.ui.screens.JobCreateScreen
 
 import android.widget.Toast
-import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -23,7 +21,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -32,9 +29,10 @@ import androidx.navigation.compose.rememberNavController
 import com.google.gson.Gson
 import hr.foi.air.baufind.R
 import hr.foi.air.baufind.core.map.MapProvider
-import hr.foi.air.baufind.core.map.models.LocationInformation
+import hr.foi.air.baufind.core.map.models.Coordinates
 import hr.foi.air.baufind.service.JobService.JobDao
 import hr.foi.air.baufind.service.JobService.JobService
+import hr.foi.air.baufind.ui.components.ExpandableText
 import hr.foi.air.baufind.ui.components.PositionAndNumber
 import hr.foi.air.baufind.ui.components.PrimaryButton
 import hr.foi.air.baufind.ui.components.PrimaryTextField
@@ -55,13 +53,12 @@ fun JobPositionsLocationScreen(
     var context = LocalContext.current
     val gson = Gson()
 
-    var locationInformation = remember { mutableStateOf(LocationInformation(45.33295293903444, 17.702489909850566)) }
+    var coordinates = remember { mutableStateOf(Coordinates(45.33295293903444, 17.702489909850566)) }
     var locationText by remember { mutableStateOf("") }
 
     val geocodingService = NetworkService.createGeocodingService()
     var geocodedLocation by remember { mutableStateOf("") }
     var locationLoaded = true
-    var locationTextIsExpanded by remember { mutableStateOf(false) }
 
     fun validateInputs(): Boolean {
         if (!locationLoaded || geocodedLocation.isBlank()) {
@@ -86,8 +83,8 @@ fun JobPositionsLocationScreen(
 
     fun updateLocation() {
         jobViewModel.location.value = getEntireLocation()
-        jobViewModel.lat.doubleValue = locationInformation.value.lat
-        jobViewModel.long.doubleValue = locationInformation.value.long
+        jobViewModel.lat.doubleValue = coordinates.value.lat
+        jobViewModel.long.doubleValue = coordinates.value.long
     }
 
     Column(
@@ -140,9 +137,9 @@ fun JobPositionsLocationScreen(
         Spacer(modifier = Modifier.height(24.dp))
         mapProvider.LocationPickerMapScreen(
             modifier = Modifier,
-            locationInformation = locationInformation.value,
-            onLocationChanged = { loc ->
-                locationInformation.value = loc
+            coordinates = coordinates.value,
+            onCoordinatesChanged = { loc ->
+                coordinates.value = loc
                 coroutineScope.launch {
                     if (!locationLoaded) {
                         return@launch
@@ -169,13 +166,9 @@ fun JobPositionsLocationScreen(
             isError = false
         )
         Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = getEntireLocation(),
-            maxLines = if (locationTextIsExpanded) Int.MAX_VALUE else 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth()
-                .clickable { locationTextIsExpanded = !locationTextIsExpanded }
-                .animateContentSize()
+        ExpandableText(
+            modifier = Modifier.fillMaxWidth(),
+            text = getEntireLocation()
         )
         Spacer(modifier = Modifier.height(24.dp))
         PrimaryButton(
@@ -224,14 +217,15 @@ fun JobPositionsLocationScreenPreview() {
             @Composable
             override fun LocationPickerMapScreen(
                 modifier: Modifier,
-                locationInformation: LocationInformation,
-                onLocationChanged: (LocationInformation) -> Unit
+                coordinates: Coordinates,
+                onCoordinatesChanged: (Coordinates) -> Unit
             ) { }
 
             @Composable
             override fun LocationShowMapScreen(
                 modifier: Modifier,
-                locationInformation: LocationInformation
+                coordinates: Coordinates,
+                location: String
             ) { }
         }
     )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobCreateScreen/JobPositionsLocationScreen.kt
@@ -118,7 +118,7 @@ fun JobPositionsLocationScreen(
             fontWeight = FontWeight.Bold
         )
         Spacer(modifier = Modifier.height(24.dp))
-        mapProvider.MapScreen(
+        mapProvider.LocationPickerMapScreen(
             modifier = Modifier,
             locationInformation = locationInformation.value
         )
@@ -168,7 +168,13 @@ fun JobPositionsLocationScreenPreview() {
         object : TokenProvider { override fun getToken(): String? { return null } },
         object : MapProvider {
             @Composable
-            override fun MapScreen(
+            override fun LocationPickerMapScreen(
+                modifier: Modifier,
+                locationInformation: LocationInformation
+            ) { }
+
+            @Composable
+            override fun LocationShowMapScreen(
                 modifier: Modifier,
                 locationInformation: LocationInformation
             ) { }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -33,14 +33,23 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
+import hr.foi.air.baufind.core.map.MapProvider
+import hr.foi.air.baufind.core.map.models.LocationInformation
 import hr.foi.air.baufind.helpers.PictureHelper
 import hr.foi.air.baufind.ui.components.DisplayTextField
 import hr.foi.air.baufind.ui.components.PrimaryButton
 import hr.foi.air.baufind.ws.network.TokenProvider
 
 @Composable
-fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel){
+fun JobSearchDetailsScreen(
+    navController: NavController,
+    tokenProvider: TokenProvider,
+    jobSearchViewModel: JobSearchViewModel,
+    mapProvider: MapProvider
+){
     val selectedJob = jobSearchViewModel.selectedJob.value
+
+    var locationInformation = remember { mutableStateOf(LocationInformation(selectedJob?.lat ?: 0.0, selectedJob?.lng ?: 0.0)) }
 
     var selectedImageIndex by remember { mutableStateOf<Int?>(null) }
     val employerId = selectedJob?.employer_id
@@ -60,6 +69,12 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
             DisplayTextField(title = "Opis posla", text = selectedJob.description)
             Spacer(modifier = Modifier.height(24.dp))
             DisplayTextField(title = "Lokacija posla", text = selectedJob.location)
+            if (selectedJob.lat != null && selectedJob.lng != null) {
+                mapProvider.LocationShowMapScreen(
+                    modifier = Modifier,
+                    locationInformation = locationInformation.value
+                )
+            }
             Spacer(modifier = Modifier.height(24.dp))
 
             PrimaryButton(
@@ -119,6 +134,25 @@ fun JobSearchDetailsScreen(navController: NavController, tokenProvider: TokenPro
 @Composable
 fun JobSearchDetailsScreenPreview() {
     val navController = rememberNavController()
-    JobSearchDetailsScreen(navController, tokenProvider = object : TokenProvider { override fun getToken(): String? { return null } }, jobSearchViewModel = JobSearchViewModel())
+    JobSearchDetailsScreen(
+        navController,
+        tokenProvider = object : TokenProvider {
+            override fun getToken(): String? { return null }
+        },
+        jobSearchViewModel = JobSearchViewModel(),
+        object : MapProvider {
+            @Composable
+            override fun LocationPickerMapScreen(
+                modifier: Modifier,
+                locationInformation: LocationInformation
+            ) { }
+
+            @Composable
+            override fun LocationShowMapScreen(
+                modifier: Modifier,
+                locationInformation: LocationInformation
+            ) { }
+        }
+    )
 }
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -49,7 +49,11 @@ fun JobSearchDetailsScreen(
 ){
     val selectedJob = jobSearchViewModel.selectedJob.value
 
-    var locationInformation = remember { mutableStateOf(LocationInformation(selectedJob?.lat ?: 0.0, selectedJob?.lng ?: 0.0)) }
+    var locationInformation = remember { mutableStateOf(LocationInformation(
+        selectedJob?.lat ?: 0.0,
+        selectedJob?.lng ?: 0.0,
+        selectedJob?.location ?: "Lokacija posla"
+    )) }
 
     var selectedImageIndex by remember { mutableStateOf<Int?>(null) }
     val employerId = selectedJob?.employer_id

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -35,6 +35,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.core.map.MapProvider
 import hr.foi.air.baufind.core.map.models.Coordinates
+import hr.foi.air.baufind.helpers.MapHelper
 import hr.foi.air.baufind.helpers.PictureHelper
 import hr.foi.air.baufind.ui.components.DisplayTextField
 import hr.foi.air.baufind.ui.components.PrimaryButton
@@ -44,8 +45,7 @@ import hr.foi.air.baufind.ws.network.TokenProvider
 fun JobSearchDetailsScreen(
     navController: NavController,
     tokenProvider: TokenProvider,
-    jobSearchViewModel: JobSearchViewModel,
-    mapProvider: MapProvider
+    jobSearchViewModel: JobSearchViewModel
 ){
     val selectedJob = jobSearchViewModel.selectedJob.value
 
@@ -73,7 +73,7 @@ fun JobSearchDetailsScreen(
             Spacer(modifier = Modifier.height(24.dp))
             DisplayTextField(title = "Lokacija posla", text = selectedJob.location)
             if (selectedJob.lat != null && selectedJob.lng != null) {
-                mapProvider.LocationShowMapScreen(
+                MapHelper.mapProvider.LocationShowMapScreen(
                     modifier = Modifier,
                     location = selectedJob.location,
                     coordinates = coordinates.value
@@ -143,22 +143,7 @@ fun JobSearchDetailsScreenPreview() {
         tokenProvider = object : TokenProvider {
             override fun getToken(): String? { return null }
         },
-        jobSearchViewModel = JobSearchViewModel(),
-        object : MapProvider {
-            @Composable
-            override fun LocationPickerMapScreen(
-                modifier: Modifier,
-                coordinates: Coordinates,
-                onCoordinatesChanged: (Coordinates) -> Unit
-            ) { }
-
-            @Composable
-            override fun LocationShowMapScreen(
-                modifier: Modifier,
-                coordinates: Coordinates,
-                location: String
-            ) { }
-        }
+        jobSearchViewModel = JobSearchViewModel()
     )
 }
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.core.map.MapProvider
-import hr.foi.air.baufind.core.map.models.LocationInformation
+import hr.foi.air.baufind.core.map.models.Coordinates
 import hr.foi.air.baufind.helpers.PictureHelper
 import hr.foi.air.baufind.ui.components.DisplayTextField
 import hr.foi.air.baufind.ui.components.PrimaryButton
@@ -49,10 +49,9 @@ fun JobSearchDetailsScreen(
 ){
     val selectedJob = jobSearchViewModel.selectedJob.value
 
-    var locationInformation = remember { mutableStateOf(LocationInformation(
+    var coordinates = remember { mutableStateOf(Coordinates(
         selectedJob?.lat ?: 0.0,
-        selectedJob?.lng ?: 0.0,
-        selectedJob?.location ?: "Lokacija posla"
+        selectedJob?.lng ?: 0.0
     )) }
 
     var selectedImageIndex by remember { mutableStateOf<Int?>(null) }
@@ -76,7 +75,8 @@ fun JobSearchDetailsScreen(
             if (selectedJob.lat != null && selectedJob.lng != null) {
                 mapProvider.LocationShowMapScreen(
                     modifier = Modifier,
-                    locationInformation = locationInformation.value
+                    location = selectedJob.location,
+                    coordinates = coordinates.value
                 )
             }
             Spacer(modifier = Modifier.height(24.dp))
@@ -148,13 +148,15 @@ fun JobSearchDetailsScreenPreview() {
             @Composable
             override fun LocationPickerMapScreen(
                 modifier: Modifier,
-                locationInformation: LocationInformation
+                coordinates: Coordinates,
+                onCoordinatesChanged: (Coordinates) -> Unit
             ) { }
 
             @Composable
             override fun LocationShowMapScreen(
                 modifier: Modifier,
-                locationInformation: LocationInformation
+                coordinates: Coordinates,
+                location: String
             ) { }
         }
     )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/Settings/MapProviderSelection.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/Settings/MapProviderSelection.kt
@@ -1,0 +1,44 @@
+package hr.foi.air.baufind.ui.screens.Settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import hr.foi.air.baufind.helpers.MapHelper
+
+@Composable
+fun MapProviderSelection() {
+    var selectedProvider by remember { mutableStateOf(MapHelper.mapProvider) }
+
+    Column {
+        MapHelper.mapProviders.forEach { provider ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+            ) {
+                RadioButton(
+                    selected = provider == selectedProvider,
+                    onClick = {
+                        selectedProvider = provider
+                        MapHelper.mapProvider = provider
+                    }
+                )
+                Text(
+                    text = provider::class.java.simpleName,
+                    modifier = Modifier.align(Alignment.CenterVertically)
+                )
+            }
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/Settings/SettingsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/Settings/SettingsScreen.kt
@@ -1,0 +1,30 @@
+package hr.foi.air.baufind.ui.screens.Settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+
+@Composable
+fun SettingsScreen(navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(22.dp)
+    ) {
+        Text(
+            text ="Postavke",
+            modifier = Modifier.align(Alignment.CenterHorizontally),
+            fontSize = 26.sp,
+            fontWeight = FontWeight.Bold
+        )
+        MapProviderSelection()
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/UserProfileScreen/UserProfileScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/UserProfileScreen/UserProfileScreen.kt
@@ -179,6 +179,12 @@ fun userProfileScreen(
                                     onDismissRequest = { showMenu = false }
                                 ) {
                                     DropdownMenuItem(
+                                        text = { Text("Settings") },
+                                        onClick = {
+                                            navController.navigate("settingsScreen")
+                                        }
+                                    )
+                                    DropdownMenuItem(
                                         text = { Text("Delete account") },
                                         onClick = {
                                             showMenu = false

--- a/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/MapProvider.kt
+++ b/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/MapProvider.kt
@@ -6,7 +6,13 @@ import hr.foi.air.baufind.core.map.models.LocationInformation
 
 interface MapProvider {
     @Composable
-    fun MapScreen(
+    fun LocationPickerMapScreen(
+        modifier: Modifier,
+        locationInformation: LocationInformation
+    )
+
+    @Composable
+    fun LocationShowMapScreen(
         modifier: Modifier,
         locationInformation: LocationInformation
     )

--- a/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/MapProvider.kt
+++ b/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/MapProvider.kt
@@ -8,7 +8,8 @@ interface MapProvider {
     @Composable
     fun LocationPickerMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation
+        locationInformation: LocationInformation,
+        onLocationChanged: (LocationInformation) -> Unit
     )
 
     @Composable

--- a/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/MapProvider.kt
+++ b/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/MapProvider.kt
@@ -2,19 +2,20 @@ package hr.foi.air.baufind.core.map
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import hr.foi.air.baufind.core.map.models.LocationInformation
+import hr.foi.air.baufind.core.map.models.Coordinates
 
 interface MapProvider {
     @Composable
     fun LocationPickerMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation,
-        onLocationChanged: (LocationInformation) -> Unit
+        coordinates: Coordinates,
+        onCoordinatesChanged: (Coordinates) -> Unit
     )
 
     @Composable
     fun LocationShowMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation
+        coordinates: Coordinates,
+        location: String
     )
 }

--- a/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/annotations/MapProviderModule.kt
+++ b/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/annotations/MapProviderModule.kt
@@ -1,0 +1,5 @@
+package hr.foi.air.baufind.core.map.annotations
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MapProviderModule

--- a/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/annotations/MapProviderModule.kt
+++ b/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/annotations/MapProviderModule.kt
@@ -1,5 +1,0 @@
-package hr.foi.air.baufind.core.map.annotations
-
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.RUNTIME)
-annotation class MapProviderModule

--- a/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/models/Coordinates.kt
+++ b/Software/Frontend/core/src/main/java/hr/foi/air/baufind/core/map/models/Coordinates.kt
@@ -1,8 +1,7 @@
 package hr.foi.air.baufind.core.map.models
 
-data class LocationInformation(
+data class Coordinates(
     var lat: Double,
     var long: Double,
-    var location: String = "",
     var isValid: Boolean = false
 )

--- a/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
+++ b/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
@@ -16,10 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import hr.foi.air.baufind.core.map.MapProvider
-import hr.foi.air.baufind.core.map.annotations.MapProviderModule
 import hr.foi.air.baufind.core.map.models.Coordinates
 
-@MapProviderModule
 class ExampleMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(

--- a/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
+++ b/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
@@ -16,8 +16,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import hr.foi.air.baufind.core.map.MapProvider
+import hr.foi.air.baufind.core.map.annotations.MapProviderModule
 import hr.foi.air.baufind.core.map.models.Coordinates
 
+@MapProviderModule
 class ExampleMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(

--- a/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
+++ b/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
@@ -16,14 +16,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import hr.foi.air.baufind.core.map.MapProvider
-import hr.foi.air.baufind.core.map.models.LocationInformation
+import hr.foi.air.baufind.core.map.models.Coordinates
 
 class ExampleMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation,
-        onLocationChanged: (LocationInformation) -> Unit
+        coordinates: Coordinates,
+        onCoordinatesChanged: (Coordinates) -> Unit
     ) {
         var latText by remember { mutableStateOf("0.0") }
         var longText by remember { mutableStateOf("0.0") }
@@ -37,15 +37,15 @@ class ExampleMapProvider : MapProvider {
                 latText = it
                 val lat = latText.toDoubleOrNull()
                 if (lat != null) {
-                    locationInformation.lat = lat
+                    coordinates.lat = lat
                     latError = ""
-                    locationInformation.isValid = longError == ""
-                    if (locationInformation.isValid) {
-                        onLocationChanged(locationInformation)
+                    coordinates.isValid = longError == ""
+                    if (coordinates.isValid) {
+                        onCoordinatesChanged(coordinates)
                     }
                 } else {
-                    locationInformation.lat = 0.0
-                    locationInformation.isValid = false
+                    coordinates.lat = 0.0
+                    coordinates.isValid = false
                     latError = "Morate unijeti validan lat"
                 }
             },
@@ -71,15 +71,15 @@ class ExampleMapProvider : MapProvider {
                 longText = it
                 val long = longText.toDoubleOrNull()
                 if (long != null) {
-                    locationInformation.long = long
+                    coordinates.long = long
                     longError = ""
-                    locationInformation.isValid = latError == ""
-                    if (locationInformation.isValid) {
-                        onLocationChanged(locationInformation)
+                    coordinates.isValid = latError == ""
+                    if (coordinates.isValid) {
+                        onCoordinatesChanged(coordinates)
                     }
                 } else {
-                    locationInformation.long = 0.0
-                    locationInformation.isValid = false
+                    coordinates.long = 0.0
+                    coordinates.isValid = false
                     longError = "Morate unijeti validan lat"
                 }
             },
@@ -103,13 +103,14 @@ class ExampleMapProvider : MapProvider {
     @Composable
     override fun LocationShowMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation
+        coordinates: Coordinates,
+        location: String
     ) {
         Text(
-            text = "Lat: ${locationInformation.lat}",
+            text = "Lat: ${coordinates.lat}",
         )
         Text(
-            text = "Lng: ${locationInformation.long}",
+            text = "Lng: ${coordinates.long}",
         )
     }
 }

--- a/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
+++ b/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
@@ -20,7 +20,7 @@ import hr.foi.air.baufind.core.map.models.LocationInformation
 
 class ExampleMapProvider : MapProvider {
     @Composable
-    override fun MapScreen(
+    override fun LocationPickerMapScreen(
         modifier: Modifier,
         locationInformation: LocationInformation
     ) {
@@ -122,5 +122,13 @@ class ExampleMapProvider : MapProvider {
             modifier = modifier.fillMaxWidth(),
             singleLine = true
         )
+    }
+
+    @Composable
+    override fun LocationShowMapScreen(
+        modifier: Modifier,
+        locationInformation: LocationInformation
+    ) {
+        Text("TODO")
     }
 }

--- a/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
+++ b/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
@@ -22,45 +22,15 @@ class ExampleMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation
+        locationInformation: LocationInformation,
+        onLocationChanged: (LocationInformation) -> Unit
     ) {
-        var locationText by remember { mutableStateOf("") }
         var latText by remember { mutableStateOf("0.0") }
         var longText by remember { mutableStateOf("0.0") }
 
-        var locationError by remember { mutableStateOf("") }
         var latError by remember { mutableStateOf("") }
         var longError by remember { mutableStateOf("") }
 
-        TextField(
-            value = locationText,
-            onValueChange = {
-                locationText = it
-                locationInformation.location = locationText
-                if (locationText != "") {
-                    locationError = ""
-                    locationInformation.isValid = (latError == "" && longError == "")
-                } else {
-                    locationError = "Morate unijeti lokaciju"
-                    locationInformation.isValid = true
-                }
-            },
-            label = { Text(text = "Lokacija") },
-            isError = (locationError != ""),
-            supportingText = {
-                if (locationError != "") {
-                    Text(locationError, color = Color.Red)
-                }
-            },
-            colors = TextFieldDefaults.colors(
-                unfocusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                focusedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                errorContainerColor = MaterialTheme.colorScheme.errorContainer
-            ),
-            modifier = modifier.fillMaxWidth(),
-            singleLine = true
-        )
-        Spacer(modifier = Modifier.height(16.dp))
         TextField(
             value = latText,
             onValueChange = {
@@ -69,7 +39,10 @@ class ExampleMapProvider : MapProvider {
                 if (lat != null) {
                     locationInformation.lat = lat
                     latError = ""
-                    locationInformation.isValid = (longError == "" && locationError == "" && locationText != "")
+                    locationInformation.isValid = longError == ""
+                    if (locationInformation.isValid) {
+                        onLocationChanged(locationInformation)
+                    }
                 } else {
                     locationInformation.lat = 0.0
                     locationInformation.isValid = false
@@ -100,7 +73,10 @@ class ExampleMapProvider : MapProvider {
                 if (long != null) {
                     locationInformation.long = long
                     longError = ""
-                    locationInformation.isValid = (latError == "" && locationError == "" && locationText != "")
+                    locationInformation.isValid = latError == ""
+                    if (locationInformation.isValid) {
+                        onLocationChanged(locationInformation)
+                    }
                 } else {
                     locationInformation.long = 0.0
                     locationInformation.isValid = false

--- a/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
+++ b/Software/Frontend/example_map/src/main/java/hr/foi/air/baufind/example_map/ExampleMapProvider.kt
@@ -129,6 +129,11 @@ class ExampleMapProvider : MapProvider {
         modifier: Modifier,
         locationInformation: LocationInformation
     ) {
-        Text("TODO")
+        Text(
+            text = "Lat: ${locationInformation.lat}",
+        )
+        Text(
+            text = "Lng: ${locationInformation.long}",
+        )
     }
 }

--- a/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
+++ b/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
@@ -113,6 +113,25 @@ class GoogleMapProvider : MapProvider {
         modifier: Modifier,
         locationInformation: LocationInformation
     ) {
-        Text("TODO")
+        var isMapLoaded by remember { mutableStateOf(false) }
+        val cameraPositionState = rememberCameraPositionState {
+            position = CameraPosition.fromLatLngZoom(
+                LatLng(locationInformation.lat, locationInformation.long),
+                15.0f
+            )
+        }
+
+        GoogleMap(
+            modifier = modifier
+                .fillMaxWidth()
+                .aspectRatio(4f/3f),
+            onMapLoaded = { isMapLoaded = true },
+            cameraPositionState = cameraPositionState
+        ) {
+            Marker(
+                state = rememberMarkerState(position = LatLng(locationInformation.lat, locationInformation.long)),
+                title = locationInformation.location
+            )
+        }
     }
 }

--- a/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
+++ b/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
@@ -18,8 +18,10 @@ import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 import hr.foi.air.baufind.core.map.MapProvider
+import hr.foi.air.baufind.core.map.annotations.MapProviderModule
 import hr.foi.air.baufind.core.map.models.Coordinates
 
+@MapProviderModule
 class GoogleMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(

--- a/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
+++ b/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
@@ -18,10 +18,8 @@ import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 import hr.foi.air.baufind.core.map.MapProvider
-import hr.foi.air.baufind.core.map.annotations.MapProviderModule
 import hr.foi.air.baufind.core.map.models.Coordinates
 
-@MapProviderModule
 class GoogleMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(

--- a/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
+++ b/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
@@ -30,7 +30,7 @@ import hr.foi.air.baufind.core.map.models.LocationInformation
 
 class GoogleMapProvider : MapProvider {
     @Composable
-    override fun MapScreen(modifier: Modifier, locationInformation: LocationInformation) {
+    override fun LocationPickerMapScreen(modifier: Modifier, locationInformation: LocationInformation) {
         var isMapLoaded by remember { mutableStateOf(false) }
         val cameraPositionState = rememberCameraPositionState {
             position = CameraPosition.fromLatLngZoom(
@@ -106,5 +106,13 @@ class GoogleMapProvider : MapProvider {
                 )
             }
         }
+    }
+
+    @Composable
+    override fun LocationShowMapScreen(
+        modifier: Modifier,
+        locationInformation: LocationInformation
+    ) {
+        Text("TODO")
     }
 }

--- a/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
+++ b/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
@@ -18,25 +18,25 @@ import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
 import hr.foi.air.baufind.core.map.MapProvider
-import hr.foi.air.baufind.core.map.models.LocationInformation
+import hr.foi.air.baufind.core.map.models.Coordinates
 
 class GoogleMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation,
-        onLocationChanged: (LocationInformation) -> Unit
+        coordinates: Coordinates,
+        onCoordinatesChanged: (Coordinates) -> Unit
     ) {
         var isMapLoaded by remember { mutableStateOf(false) }
         val cameraPositionState = rememberCameraPositionState {
             position = CameraPosition.fromLatLngZoom(
-                LatLng(locationInformation.lat, locationInformation.long),
+                LatLng(coordinates.lat, coordinates.long),
                 15.0f
             )
         }
 
-        var lat by remember { mutableDoubleStateOf(locationInformation.lat) }
-        var long by remember { mutableDoubleStateOf(locationInformation.long) }
+        var lat by remember { mutableDoubleStateOf(coordinates.lat) }
+        var long by remember { mutableDoubleStateOf(coordinates.long) }
         var valid by remember { mutableStateOf(false) }
 
         val context = LocalContext.current
@@ -44,19 +44,19 @@ class GoogleMapProvider : MapProvider {
         GoogleMap(
             modifier = Modifier
                 .fillMaxWidth()
-                .aspectRatio(4f/3f),
+                .aspectRatio(16f/9f),
             onMapLoaded = { isMapLoaded = true },
             cameraPositionState = cameraPositionState,
-            onMapLongClick = { coordinates ->
-                locationInformation.lat = coordinates.latitude
-                locationInformation.long = coordinates.longitude
-                locationInformation.isValid = true
+            onMapLongClick = { coord ->
+                coordinates.lat = coord.latitude
+                coordinates.long = coord.longitude
+                coordinates.isValid = true
 
-                lat = locationInformation.lat
-                long = locationInformation.long
+                lat = coordinates.lat
+                long = coordinates.long
                 valid = true
 
-                onLocationChanged(locationInformation)
+                onCoordinatesChanged(coordinates)
             },
             onMapClick = {
                 Toast.makeText(context, "Držite dugi klik da biste odabrali lokaciju", Toast.LENGTH_SHORT).show()
@@ -74,12 +74,13 @@ class GoogleMapProvider : MapProvider {
     @Composable
     override fun LocationShowMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation
+        coordinates: Coordinates,
+        location: String
     ) {
         var isMapLoaded by remember { mutableStateOf(false) }
         val cameraPositionState = rememberCameraPositionState {
             position = CameraPosition.fromLatLngZoom(
-                LatLng(locationInformation.lat, locationInformation.long),
+                LatLng(coordinates.lat, coordinates.long),
                 15.0f
             )
         }
@@ -92,8 +93,8 @@ class GoogleMapProvider : MapProvider {
             cameraPositionState = cameraPositionState
         ) {
             Marker(
-                state = rememberMarkerState(position = LatLng(locationInformation.lat, locationInformation.long)),
-                title = locationInformation.location
+                state = rememberMarkerState(position = LatLng(coordinates.lat, coordinates.long)),
+                title = location
             )
         }
     }

--- a/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
+++ b/Software/Frontend/google_map/src/main/java/hr/foi/air/baufind/google_map/GoogleMapProvider.kt
@@ -1,14 +1,8 @@
 package hr.foi.air.baufind.google_map
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
@@ -16,9 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
@@ -30,7 +22,11 @@ import hr.foi.air.baufind.core.map.models.LocationInformation
 
 class GoogleMapProvider : MapProvider {
     @Composable
-    override fun LocationPickerMapScreen(modifier: Modifier, locationInformation: LocationInformation) {
+    override fun LocationPickerMapScreen(
+        modifier: Modifier,
+        locationInformation: LocationInformation,
+        onLocationChanged: (LocationInformation) -> Unit
+    ) {
         var isMapLoaded by remember { mutableStateOf(false) }
         val cameraPositionState = rememberCameraPositionState {
             position = CameraPosition.fromLatLngZoom(
@@ -39,45 +35,12 @@ class GoogleMapProvider : MapProvider {
             )
         }
 
-        var locationText by remember { mutableStateOf("") }
         var lat by remember { mutableDoubleStateOf(locationInformation.lat) }
         var long by remember { mutableDoubleStateOf(locationInformation.long) }
-        var valid by remember { mutableStateOf(locationInformation.isValid) }
-
-        var locationError by remember { mutableStateOf("") }
-        var markerValid by remember { mutableStateOf(false) }
+        var valid by remember { mutableStateOf(false) }
 
         val context = LocalContext.current
 
-        TextField(
-            value = locationText,
-            onValueChange = {
-                locationText = it
-                locationInformation.location = locationText
-                if (locationText != "") {
-                    locationError = ""
-                    locationInformation.isValid = markerValid
-                } else {
-                    locationError = "Morate unijeti lokaciju"
-                    locationInformation.isValid = true
-                }
-            },
-            label = { Text(text = "Lokacija") },
-            isError = (locationError != ""),
-            supportingText = {
-                if (locationError != "") {
-                    Text(locationError, color = Color.Red)
-                }
-            },
-            colors = TextFieldDefaults.colors(
-                unfocusedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                focusedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
-                errorContainerColor = MaterialTheme.colorScheme.errorContainer
-            ),
-            modifier = modifier.fillMaxWidth(),
-            singleLine = true
-        )
-        Spacer(modifier = Modifier.height(16.dp))
         GoogleMap(
             modifier = Modifier
                 .fillMaxWidth()
@@ -85,21 +48,21 @@ class GoogleMapProvider : MapProvider {
             onMapLoaded = { isMapLoaded = true },
             cameraPositionState = cameraPositionState,
             onMapLongClick = { coordinates ->
-                markerValid = true
-
                 locationInformation.lat = coordinates.latitude
                 locationInformation.long = coordinates.longitude
-                locationInformation.isValid = locationError == "" && locationText != ""
+                locationInformation.isValid = true
 
                 lat = locationInformation.lat
                 long = locationInformation.long
-                valid = locationInformation.isValid
+                valid = true
+
+                onLocationChanged(locationInformation)
             },
             onMapClick = {
                 Toast.makeText(context, "Držite dugi klik da biste odabrali lokaciju", Toast.LENGTH_SHORT).show()
             }
         ) {
-            if (markerValid) {
+            if (valid) {
                 Marker(
                     state = rememberMarkerState(position = LatLng(lat, long)),
                     title = "Odabrana lokacija"

--- a/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
+++ b/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
@@ -12,13 +12,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.utsman.osmandcompose.Marker
 import com.utsman.osmandcompose.OpenStreetMap
@@ -26,15 +24,15 @@ import com.utsman.osmandcompose.rememberCameraState
 import com.utsman.osmandcompose.rememberMarkerState
 import hr.foi.air.baufind.core.map.MapProvider
 import hr.foi.air.baufind.core.map.models.LocationInformation
-import hr.foi.air.baufind.ws.network.NetworkService
-import kotlinx.coroutines.launch
 import org.osmdroid.util.GeoPoint
 
 class OpenStreetMapProvider : MapProvider {
     @Composable
-    override fun LocationPickerMapScreen(modifier: Modifier, locationInformation: LocationInformation) {
-        val geocodingService = NetworkService.createGeocodingService()
-
+    override fun LocationPickerMapScreen(
+        modifier: Modifier,
+        locationInformation: LocationInformation,
+        onLocationChanged: (LocationInformation) -> Unit
+    ) {
         val cameraState = rememberCameraState {
             geoPoint = GeoPoint(locationInformation.lat, locationInformation.long)
             zoom = 15.0
@@ -48,22 +46,12 @@ class OpenStreetMapProvider : MapProvider {
         var long by remember { mutableDoubleStateOf(locationInformation.long) }
         var valid by remember { mutableStateOf(locationInformation.isValid) }
 
-        var markerValid by remember { mutableStateOf(false) }
-        var locationText by remember { mutableStateOf("") }
-
         val context = LocalContext.current
-        val coroutineScope = rememberCoroutineScope()
 
         Column(
             verticalArrangement = Arrangement.SpaceBetween,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(
-                text = "Lokacija: $locationText",
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.fillMaxWidth()
-            )
             OpenStreetMap(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -71,31 +59,16 @@ class OpenStreetMapProvider : MapProvider {
                     .clip(AbsoluteCutCornerShape(0.dp)),
                 cameraState = cameraState,
                 onMapLongClick = { geoPoint ->
-                    markerValid = true
-
                     locationInformation.lat = geoPoint.latitude
                     locationInformation.long = geoPoint.longitude
+                    locationInformation.isValid = true
 
                     lat = locationInformation.lat
                     long = locationInformation.long
+                    valid = true
 
                     markerState.geoPoint = geoPoint
-                    coroutineScope.launch {
-                        locationInformation.location = ""
-                        locationText = "Učitavam lokaciju..."
-                        locationInformation.isValid = false
-                        valid = false
-                        try {
-                            val geocodingResponse = geocodingService.reverseGeocode(lat, long)
-                            locationInformation.location = geocodingResponse.location ?: "Nepoznata lokacija"
-                            locationText = locationInformation.location
-                            locationInformation.isValid = true
-                            valid = true
-                        } catch (e: Exception) {
-                            locationInformation.location = ""
-                            locationText = "Greška pri dohvaćanju lokacije"
-                        }
-                    }
+                    onLocationChanged(locationInformation)
                 },
                 onMapClick = {
                     Toast.makeText(context, "Držite dugi klik da biste odabrali lokaciju", Toast.LENGTH_SHORT).show()
@@ -103,9 +76,9 @@ class OpenStreetMapProvider : MapProvider {
             ) {
                 Marker(
                     state = markerState,
-                    visible = markerValid,
+                    visible = valid,
                     infoWindowContent = {
-                        Text(locationText)
+                        Text("Odabrana lokacija")
                     }
                 )
             }

--- a/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
+++ b/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
@@ -117,6 +117,26 @@ class OpenStreetMapProvider : MapProvider {
         modifier: Modifier,
         locationInformation: LocationInformation
     ) {
-        Text("TODO")
+        val cameraState = rememberCameraState {
+            geoPoint = GeoPoint(locationInformation.lat, locationInformation.long)
+            zoom = 15.0
+        }
+
+        OpenStreetMap(
+            modifier = modifier
+                .fillMaxWidth()
+                .aspectRatio(4f/3f)
+                .clip(AbsoluteCutCornerShape(0.dp)),
+            cameraState = cameraState
+        ) {
+            Marker(
+                state = rememberMarkerState(
+                    geoPoint = GeoPoint(locationInformation.lat, locationInformation.long)
+                ),
+                infoWindowContent = {
+                    Text(locationInformation.location)
+                }
+            )
+        }
     }
 }

--- a/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
+++ b/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
@@ -20,9 +20,11 @@ import com.utsman.osmandcompose.OpenStreetMap
 import com.utsman.osmandcompose.rememberCameraState
 import com.utsman.osmandcompose.rememberMarkerState
 import hr.foi.air.baufind.core.map.MapProvider
+import hr.foi.air.baufind.core.map.annotations.MapProviderModule
 import hr.foi.air.baufind.core.map.models.Coordinates
 import org.osmdroid.util.GeoPoint
 
+@MapProviderModule
 class OpenStreetMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(

--- a/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
+++ b/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
@@ -32,7 +32,7 @@ import org.osmdroid.util.GeoPoint
 
 class OpenStreetMapProvider : MapProvider {
     @Composable
-    override fun MapScreen(modifier: Modifier, locationInformation: LocationInformation) {
+    override fun LocationPickerMapScreen(modifier: Modifier, locationInformation: LocationInformation) {
         val geocodingService = NetworkService.createGeocodingService()
 
         val cameraState = rememberCameraState {
@@ -110,5 +110,13 @@ class OpenStreetMapProvider : MapProvider {
                 )
             }
         }
+    }
+
+    @Composable
+    override fun LocationShowMapScreen(
+        modifier: Modifier,
+        locationInformation: LocationInformation
+    ) {
+        Text("TODO")
     }
 }

--- a/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
+++ b/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
@@ -20,11 +20,9 @@ import com.utsman.osmandcompose.OpenStreetMap
 import com.utsman.osmandcompose.rememberCameraState
 import com.utsman.osmandcompose.rememberMarkerState
 import hr.foi.air.baufind.core.map.MapProvider
-import hr.foi.air.baufind.core.map.annotations.MapProviderModule
 import hr.foi.air.baufind.core.map.models.Coordinates
 import org.osmdroid.util.GeoPoint
 
-@MapProviderModule
 class OpenStreetMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(

--- a/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
+++ b/Software/Frontend/open_street_map/src/main/java/hr/foi/air/baufind/open_street_map/OpenStreetMapProvider.kt
@@ -1,8 +1,6 @@
 package hr.foi.air.baufind.open_street_map
 
 import android.widget.Toast
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.AbsoluteCutCornerShape
@@ -13,7 +11,6 @@ import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
@@ -23,75 +20,71 @@ import com.utsman.osmandcompose.OpenStreetMap
 import com.utsman.osmandcompose.rememberCameraState
 import com.utsman.osmandcompose.rememberMarkerState
 import hr.foi.air.baufind.core.map.MapProvider
-import hr.foi.air.baufind.core.map.models.LocationInformation
+import hr.foi.air.baufind.core.map.models.Coordinates
 import org.osmdroid.util.GeoPoint
 
 class OpenStreetMapProvider : MapProvider {
     @Composable
     override fun LocationPickerMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation,
-        onLocationChanged: (LocationInformation) -> Unit
+        coordinates: Coordinates,
+        onCoordinatesChanged: (Coordinates) -> Unit
     ) {
         val cameraState = rememberCameraState {
-            geoPoint = GeoPoint(locationInformation.lat, locationInformation.long)
+            geoPoint = GeoPoint(coordinates.lat, coordinates.long)
             zoom = 15.0
         }
 
         val markerState = rememberMarkerState(
-            geoPoint = GeoPoint(locationInformation.lat, locationInformation.long)
+            geoPoint = GeoPoint(coordinates.lat, coordinates.long)
         )
 
-        var lat by remember { mutableDoubleStateOf(locationInformation.lat) }
-        var long by remember { mutableDoubleStateOf(locationInformation.long) }
-        var valid by remember { mutableStateOf(locationInformation.isValid) }
+        var lat by remember { mutableDoubleStateOf(coordinates.lat) }
+        var long by remember { mutableDoubleStateOf(coordinates.long) }
+        var valid by remember { mutableStateOf(coordinates.isValid) }
 
         val context = LocalContext.current
 
-        Column(
-            verticalArrangement = Arrangement.SpaceBetween,
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            OpenStreetMap(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(4f/3f)
-                    .clip(AbsoluteCutCornerShape(0.dp)),
-                cameraState = cameraState,
-                onMapLongClick = { geoPoint ->
-                    locationInformation.lat = geoPoint.latitude
-                    locationInformation.long = geoPoint.longitude
-                    locationInformation.isValid = true
+        OpenStreetMap(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16f/9f)
+                .clip(AbsoluteCutCornerShape(0.dp)),
+            cameraState = cameraState,
+            onMapLongClick = { geoPoint ->
+                coordinates.lat = geoPoint.latitude
+                coordinates.long = geoPoint.longitude
+                coordinates.isValid = true
 
-                    lat = locationInformation.lat
-                    long = locationInformation.long
-                    valid = true
+                lat = coordinates.lat
+                long = coordinates.long
+                valid = true
 
-                    markerState.geoPoint = geoPoint
-                    onLocationChanged(locationInformation)
-                },
-                onMapClick = {
-                    Toast.makeText(context, "Držite dugi klik da biste odabrali lokaciju", Toast.LENGTH_SHORT).show()
-                }
-            ) {
-                Marker(
-                    state = markerState,
-                    visible = valid,
-                    infoWindowContent = {
-                        Text("Odabrana lokacija")
-                    }
-                )
+                markerState.geoPoint = geoPoint
+                onCoordinatesChanged(coordinates)
+            },
+            onMapClick = {
+                Toast.makeText(context, "Držite dugi klik da biste odabrali lokaciju", Toast.LENGTH_SHORT).show()
             }
+        ) {
+            Marker(
+                state = markerState,
+                visible = valid,
+                infoWindowContent = {
+                    Text("Odabrana lokacija")
+                }
+            )
         }
     }
 
     @Composable
     override fun LocationShowMapScreen(
         modifier: Modifier,
-        locationInformation: LocationInformation
+        coordinates: Coordinates,
+        location: String
     ) {
         val cameraState = rememberCameraState {
-            geoPoint = GeoPoint(locationInformation.lat, locationInformation.long)
+            geoPoint = GeoPoint(coordinates.lat, coordinates.long)
             zoom = 15.0
         }
 
@@ -104,10 +97,10 @@ class OpenStreetMapProvider : MapProvider {
         ) {
             Marker(
                 state = rememberMarkerState(
-                    geoPoint = GeoPoint(locationInformation.lat, locationInformation.long)
+                    geoPoint = GeoPoint(coordinates.lat, coordinates.long)
                 ),
                 infoWindowContent = {
-                    Text(locationInformation.location)
+                    Text(location)
                 }
             )
         }


### PR DESCRIPTION
Ovaj PR rješava sljedeći zadatak: https://vlovric21.atlassian.net/browse/BAUF-81

## Što je dodano

Dodan je prikaz mape kod detalja posla:
<img alt="google map prikaz" src="https://github.com/user-attachments/assets/eb32a5ed-d223-4cda-8e64-f35e349cf16a" />
<img alt="open street map prikaz" src="https://github.com/user-attachments/assets/cfb9e589-0120-4fa3-b3aa-badc45638ca2" />

Sada se mapa može birati u postavkama:

<img alt="opcije 1" src="https://github.com/user-attachments/assets/18e0bc2a-a814-4df3-9e71-e0ce9c0f5e46" />
<img alt="postavke" src="https://github.com/user-attachments/assets/9f60273a-c064-41a0-948a-b0399ad65597" />

Dodan je i novi element **ExpandableText** koji se poveća i smanji na klik, tako da prikazuje samo jedan red, ili sve redove (ima i animaciju):

<img alt="prošireno" src="https://github.com/user-attachments/assets/8bc3127b-5ab5-41cc-acf5-bca2d9da259f" />
<img alt="spušteno" src="https://github.com/user-attachments/assets/15cf1895-27eb-405e-b05e-63f324e09acd" />

## Što je refaktorirano

Dosta je kod refaktoriran vezan uz te karte, moduli su sada zaduženi samo za odabir _koordinata_, a ne i unos lokacije.

Za unos lokacije koristi se Reverse Geocoding API uz dodatak dodatnog teksta, za više detalja:

<img alt="unos open street map" src="https://github.com/user-attachments/assets/1307ac7b-5e70-4b0d-a529-b5828050493a" />
<img alt="unos google map" src="https://github.com/user-attachments/assets/fc0af65f-0b0f-40be-a868-e10a96ca2447" />

**Recite ako što treba popraviti ili promijeniti. Pazite na API ključ za Google map i API ključ za geocoding.**
Gdje postaviti API ključeve, opisano je u sljedećim PR-ovima:
https://github.com/AIR-DavidoviTigrovi/baufind/pull/26
https://github.com/AIR-DavidoviTigrovi/baufind/pull/32