### PR TITLE
Bauf 109 bauf 107 dohvacanje informacija o konkretnom poslu uklanjanje slika iz poslova

### DIFF
--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJob/FullJobRecord.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJob/FullJobRecord.cs
@@ -1,0 +1,24 @@
+﻿using DataAccessLayer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BusinessLogicLayer.AppLogic.Jobs.GetJob
+{
+    public record FullJobRecord
+    {
+        public int Id { get; set; }
+        public int Employer_id { get; set; }
+        public int Job_status_id { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public bool Allow_worker_invite { get; set; }
+        public string Location { get; set; }
+        public decimal? Lat { get; set; }
+        public decimal? Lng { get; set; }
+        public List<byte[]> Pictures { get; set; }
+        public List<SkillModel> Skills { get; set; }
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJob/GetJobResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJob/GetJobResponse.cs
@@ -1,0 +1,15 @@
+﻿using DataAccessLayer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BusinessLogicLayer.AppLogic.Jobs.GetJob
+{
+    public record GetJobResponse
+    {
+        public FullJobRecord Job { get; set; } = new FullJobRecord();
+        public string? Error { get; set; } = string.Empty;
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
@@ -1,5 +1,6 @@
 ﻿using BusinessLogicLayer.AppLogic.Jobs.AddJob;
 using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
+using BusinessLogicLayer.AppLogic.Jobs.GetJob;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 using System;
 using System.Collections.Generic;
@@ -13,6 +14,7 @@ namespace BusinessLogicLayer.AppLogic.Jobs
     {
         public AddJobResponse AddJob(AddJobRequest request, int userId);
         public GetJobsForCurrentUserResponse GetJobsForCurrentUser(int userId);
+        public GetJobResponse GetJob(int jobId);
         public CallWarkerToJobResponse CallWorkerToJob(CallWorkerToJobRequest request, int userId);
         public PendingInvitationResponse GetPendingInvitations(int userId);
     }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -131,12 +131,6 @@ namespace BusinessLogicLayer.Infrastructure
                 job.Skills = _jobRepository.GetSkillsForJobWhereSkillPositionsOpen(job.Id);
             }
 
-            foreach (var job in jobs)
-            {
-                job.Pictures = _jobRepository.GetPicturesForJobWhereSkillPositionsOpen(job.Id);
-            }
-
-
             return new GetJobsForCurrentUserResponse()
             {
                 Jobs = jobs

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -2,6 +2,7 @@ using BusinessLogicLayer.AppLogic;
 using BusinessLogicLayer.AppLogic.Jobs;
 using BusinessLogicLayer.AppLogic.Jobs.AddJob;
 using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
+using BusinessLogicLayer.AppLogic.Jobs.GetJob;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 using BusinessLogicLayer.AppLogic.Skills;
 using DataAccessLayer.AppLogic;
@@ -139,6 +140,40 @@ namespace BusinessLogicLayer.Infrastructure
             return new GetJobsForCurrentUserResponse()
             {
                 Jobs = jobs
+            };
+        }
+
+        public GetJobResponse GetJob(int jobId)
+        {
+            var jobData = _jobRepository.GetJob(jobId);
+
+            if (jobData == null)
+            {
+                return new GetJobResponse()
+                {
+                    Error = "Posao nije pronađen!"
+                };
+            }
+
+            var job = new FullJobRecord()
+            {
+                Id = jobData.Id,
+                Title = jobData.Title,
+                Description = jobData.Description,
+                Allow_worker_invite = jobData.Allow_worker_invite,
+                Lat = jobData.Lat,
+                Lng = jobData.Lng,
+                Location = jobData.Location,
+                Job_status_id = jobData.Job_status_id,
+                Employer_id = jobData.Employer_id
+            };
+
+            job.Skills = _jobRepository.GetSkillsForJobWhereSkillPositionsOpen(jobData.Id);
+            job.Pictures = _jobRepository.GetPicturesForJobWhereSkillPositionsOpen(jobData.Id);
+
+            return new GetJobResponse()
+            {
+                Job = job
             };
         }
 

--- a/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
+++ b/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
@@ -37,5 +37,11 @@ namespace DataAccessLayer.AppLogic
         /// <param name="jobId"></param>
         /// <returns>Vještine za posao</returns>
         public List<SkillModel> GetSkillsForJobWhereSkillPositionsOpen(int jobId);
+        /// <summary>
+        /// Dohvaća posao po ID-u
+        /// </summary>
+        /// <param name="jobId"></param>
+        /// <returns></returns>
+        public JobModel GetJob(int jobId);
     }
 }

--- a/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
@@ -177,5 +177,36 @@ namespace DataAccessLayer.Infrastructure
             }
         }
 
+        public JobModel GetJob(int jobId)
+        {
+            string query = @"
+                SELECT * FROM job
+                WHERE id = @jobId;";
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "@jobId", jobId }
+            };
+
+            using (var reader = _db.ExecuteReader(query, parameters))
+            {
+                if (reader.Read())
+                {
+                    return new JobModel()
+                    {
+                        Id = (int)reader["id"],
+                        Employer_id = (int)reader["employer_id"],
+                        Job_status_id = (int)reader["job_status_id"],
+                        Title = (string)reader["title"],
+                        Description = (string)reader["description"],
+                        Allow_worker_invite = (bool)reader["allow_worker_invite"],
+                        Location = (string)reader["location"],
+                        Lat = reader["lat"] as decimal?,
+                        Lng = reader["lng"] as decimal?
+                    };
+                }
+                return null;
+            }
+        }
     }
 }

--- a/Software/Backend/WebApi/Controllers/JobController.cs
+++ b/Software/Backend/WebApi/Controllers/JobController.cs
@@ -2,6 +2,7 @@ using Azure;
 using BusinessLogicLayer.AppLogic.Jobs;
 using BusinessLogicLayer.AppLogic.Jobs.AddJob;
 using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
+using BusinessLogicLayer.AppLogic.Jobs.GetJob;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -44,8 +45,8 @@ public class JobController : ControllerBase
         return response;
     }
 
-    // GET: /jobsForCurrentUser
-    [HttpGet("jobsForCurrentUser")]
+    // GET: /jobs/search
+    [HttpGet("search")]
     [Authorize]
     public ActionResult<GetJobsForCurrentUserResponse> GetJobsForCurrentUser()
     {
@@ -64,6 +65,27 @@ public class JobController : ControllerBase
         return jobs;
     }
 
+    //GET: /jobs/{id}
+    [HttpGet("{id}")]
+    [Authorize]
+    public ActionResult<GetJobResponse> GetJob(int id)
+    {
+        var userIdFromJwt = HttpContext.Items["UserId"] as int?;
+
+        if (userIdFromJwt == null)
+        {
+            return Unauthorized(new GetJobResponse()
+            {
+                Error = "Ne možete pristupiti tom resursu!"
+            });
+        }
+
+        var job = _jobService.GetJob(id);
+
+        return job;
+
+    }
+    
     [HttpPut("CallForWorking")]
     [Authorize]
     public ActionResult<CallWarkerToJobResponse> CallWorkerToJob([FromBody] CallWorkerToJobRequest request)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobGetService/JobGetResponse.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobGetService/JobGetResponse.kt
@@ -1,0 +1,9 @@
+package hr.foi.air.baufind.service.JobGetService
+
+import hr.foi.air.baufind.ws.model.FullJobModel
+
+data class JobGetResponse(
+    val success: Boolean,
+    val message: String?,
+    val job: FullJobModel?
+)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobGetService/JobGetService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobGetService/JobGetService.kt
@@ -1,0 +1,36 @@
+package hr.foi.air.baufind.service.JobGetService
+
+import android.util.Log
+import hr.foi.air.baufind.ws.network.NetworkService
+import hr.foi.air.baufind.ws.network.TokenProvider
+
+class JobGetService() {
+    suspend fun fetchJobAsync(id: Int, tokenProvider: TokenProvider): JobGetResponse {
+        val service = NetworkService.createJobService(tokenProvider)
+        try {
+            val response = service.getJob(id)
+            Log.d("Response od getJob", response.toString())
+            if (response.error == "") {
+                return JobGetResponse(
+                    true,
+                    "",
+                    response.job
+                )
+            } else {
+                return JobGetResponse(
+                    false,
+                    response.error,
+                    null
+                )
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Log.d("JobGetService", "Error: ${e.message}")
+            return JobGetResponse(
+                false,
+                "Pogreska pri fetchanju",
+                null
+            )
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
@@ -79,7 +79,7 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, 
                 items(filteredJobs.size) { index ->
                     val job = filteredJobs[index]
                     JobListItem(job = job){
-                        jobSearchViewModel.selectedJob.value = job
+                        jobSearchViewModel.selectedJobId = job.id
                         navController.navigate("jobSearchDetailsScreen")
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
@@ -14,7 +14,7 @@ class JobSearchViewModel : ViewModel(){
     var success : Boolean = false
     var message : String? = null
     val jobs = mutableStateOf(emptyList<JobSearchModel>())
-    var selectedJob = mutableStateOf<JobSearchModel?>(null)
+    var selectedJobId : Int = 0
 
     var tokenProvider: TokenProvider? = null
     set(value) {
@@ -34,7 +34,7 @@ class JobSearchViewModel : ViewModel(){
     }
 
     fun clearData(){
-        selectedJob = mutableStateOf(null)
+        selectedJobId = 0
     }
 
     fun isLoading() : Boolean{

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/FullJobModel.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/FullJobModel.kt
@@ -1,0 +1,15 @@
+package hr.foi.air.baufind.ws.model
+
+data class FullJobModel(
+    val id: Int,
+    val employer_id: Int,
+    val job_status_id: Int,
+    val title: String,
+    val description: String,
+    val allow_worker_invite: Boolean,
+    val location: String,
+    val lat: Double?,
+    val lng: Double?,
+    val pictures: List<String>,
+    val skills: List<Skill>
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
@@ -2,15 +2,21 @@ package hr.foi.air.baufind.ws.network
 
 import hr.foi.air.baufind.ws.request.JobCreateBody
 import hr.foi.air.baufind.ws.response.JobCreateResponse
+import hr.foi.air.baufind.ws.response.JobResponse
 import hr.foi.air.baufind.ws.response.JobsForCurrentUserResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface JobService {
     @POST("/jobs/add")
     suspend fun addJob(@Body jobCreateBody: JobCreateBody): JobCreateResponse
 
-    @GET("/jobs/jobsForCurrentUser")
+    @GET("/jobs/search")
     suspend fun getJobsForCurrentUser(): JobsForCurrentUserResponse
+
+    @GET("/jobs/{id}")
+    suspend fun getJob(@Path("id") id: Int): JobResponse
+
 }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/JobResponse.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/JobResponse.kt
@@ -1,0 +1,8 @@
+package hr.foi.air.baufind.ws.response
+
+import hr.foi.air.baufind.ws.model.FullJobModel
+
+data class JobResponse(
+    val job : FullJobModel,
+    val error : String?
+)


### PR DESCRIPTION
## Što je napravljeno

- Napravljen je novi API koji se koristi na ekranu kada smo odabrali posao nakon pretraživanja, što znači da se sada svaki put kada se odabere posao nakon pretraživanja dohvaćaju slike samo za njega
- Maknuto je učitavanje slika iz odgovora API-a koji vraća poslove koji se pretražuju i sada je učitavanje poslova brzo

## Za imati na umu

- Pozivanje servisa ovako direktno na ekranu je privremeno rješenje, sljedeći issue koji radim je vezan uz viewmodele i refreshanje ekrana tako da to ću tamo srediti jer mi nije imalo smisla 3 issuea raditi na jedan PR. Također ovo sa != 0 je isto privremeno iz istog razloga. Isto ova loading varijabla zasad nije korištena ali će biti kad refaktoriram viewmodele.

![image](https://github.com/user-attachments/assets/d3cb1697-0541-4882-a584-060018397ccd)

- Maknuo sam učitavanje slika sa poslova koji se pretražuju tako što ih samo nisam učitao, ali atribut je ostao u klasi koja se vraća iz razloga što je već korištena u nekim drugim dijelovima backend koda koji nisu moji tako da zasad je OK da je samo uvijek null u returnu jer se to nigdje ne koristi. Ako baš trebamo možemo to refaktorirati u zadnjem sprintu. Agilno

![image](https://github.com/user-attachments/assets/4c6d892e-3017-440e-93f6-867b673df021)

