### PR TITLE
Bauf 108 osvjezavanje ekrana za pretrazivanje poslova

### DIFF
--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -128,7 +128,7 @@ namespace BusinessLogicLayer.Infrastructure
 
             foreach (var job in jobs)
             {
-                job.Skills = _jobRepository.GetSkillsForJobWhereSkillPositionsOpen(job.Id);
+                job.Skills = _jobRepository.GetSkillsForJob(job.Id);
             }
 
             return new GetJobsForCurrentUserResponse()
@@ -162,8 +162,8 @@ namespace BusinessLogicLayer.Infrastructure
                 Employer_id = jobData.Employer_id
             };
 
-            job.Skills = _jobRepository.GetSkillsForJobWhereSkillPositionsOpen(jobData.Id);
-            job.Pictures = _jobRepository.GetPicturesForJobWhereSkillPositionsOpen(jobData.Id);
+            job.Skills = _jobRepository.GetSkillsForJob(jobData.Id);
+            job.Pictures = _jobRepository.GetPicturesForJob(jobData.Id);
 
             return new GetJobResponse()
             {

--- a/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
+++ b/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
@@ -30,13 +30,13 @@ namespace DataAccessLayer.AppLogic
         /// </summary>
         /// <param name="jobId"></param>
         /// <returns>Slike za posao</returns>
-        public List<byte[]> GetPicturesForJobWhereSkillPositionsOpen(int jobId);
+        public List<byte[]> GetPicturesForJob(int jobId);
         /// <summary>
         /// Dohvaća sve vještine za posao
         /// </summary>
         /// <param name="jobId"></param>
         /// <returns>Vještine za posao</returns>
-        public List<SkillModel> GetSkillsForJobWhereSkillPositionsOpen(int jobId);
+        public List<SkillModel> GetSkillsForJob(int jobId);
         /// <summary>
         /// Dohvaća posao po ID-u
         /// </summary>

--- a/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
@@ -122,7 +122,7 @@ namespace DataAccessLayer.Infrastructure
         /// </summary>
         /// <param name="jobIds"></param>
         /// <returns>Slike za posao</returns>
-        public List<byte[]> GetPicturesForJobWhereSkillPositionsOpen(int jobId)
+        public List<byte[]> GetPicturesForJob(int jobId)
         {
             string query = $@"
                 SELECT p.picture FROM job j
@@ -150,7 +150,7 @@ namespace DataAccessLayer.Infrastructure
         /// </summary>
         /// <param name="jobId"></param>
         /// <returns>Vještine za posao</returns>
-        public List<SkillModel> GetSkillsForJobWhereSkillPositionsOpen(int jobId)
+        public List<SkillModel> GetSkillsForJob(int jobId)
         {
             string query = @"
                 SELECT s.id, s.title FROM working w

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -31,6 +31,7 @@ import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobPositionsLocationScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobViewModel
 import hr.foi.air.baufind.ui.screens.JobRoom.JobRoomScreen
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchDetailsScreen
+import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchDetailsViewModel
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchScreen
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchViewModel
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
@@ -53,6 +54,7 @@ class MainActivity : ComponentActivity() {
         val gson = Gson()
         val jobViewModel = JobViewModel()
         val jobSearchViewModel = JobSearchViewModel()
+        val jobSearchDetailsViewModel = JobSearchDetailsViewModel()
         setContent {
             val navController = rememberNavController()
             val currentRoute = navController
@@ -140,8 +142,8 @@ class MainActivity : ComponentActivity() {
                             composable("jobPositionsLocationScreen") { JobPositionsLocationScreen(navController, jobViewModel, tokenProvider) }
                             composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel, tokenProvider) }
 
-                            composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider, jobSearchViewModel) }
-                            composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchViewModel) }
+                            composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider, jobSearchViewModel, jobSearchDetailsViewModel) }
+                            composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchDetailsViewModel) }
                             composable("settingsScreen") { SettingsScreen(navController) }
 
                         }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchDetailsViewModel.kt
@@ -1,0 +1,50 @@
+package hr.foi.air.baufind.ui.screens.JobSearchScreen
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import hr.foi.air.baufind.service.JobGetService.JobGetResponse
+import hr.foi.air.baufind.service.JobGetService.JobGetService
+import hr.foi.air.baufind.ws.model.FullJobModel
+import hr.foi.air.baufind.ws.network.TokenProvider
+import kotlinx.coroutines.launch
+
+class JobSearchDetailsViewModel : ViewModel() {
+    var success : Boolean = false
+    var message : String? = null
+    var job : FullJobModel? = null
+    var selectedJobId : Int = -1
+
+    var tokenProvider: TokenProvider? = null
+    set(value){
+        field = value
+        value?.let {loadJob(it)}
+    }
+
+    private fun loadJob(tokenProvider: TokenProvider){
+        viewModelScope.launch {
+            val service = JobGetService()
+            Log.d("JobSearchDetailsViewModel", "Selected job id: $selectedJobId")
+            val response : JobGetResponse = service.fetchJobAsync(selectedJobId, tokenProvider)
+            success = response.success
+            message = response.message
+            job = response.job
+        }
+    }
+
+    fun clearData(){
+        success = false
+        message = null
+        job = null
+    }
+
+    fun isLoading() : Boolean{
+        return job == null && message == null
+    }
+
+    fun HasError() : Boolean{
+        return job == null && message != null
+    }
+
+
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import hr.foi.air.baufind.service.JobSearchService.JobSearchResponse
 import hr.foi.air.baufind.service.JobSearchService.JobSearchService
@@ -33,8 +34,11 @@ import hr.foi.air.baufind.ws.network.TokenProvider
 import kotlinx.coroutines.launch
 
 @Composable
-fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel){
-    LaunchedEffect(Unit){
+fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, jobSearchViewModel: JobSearchViewModel, jobSearchDetailsViewModel : JobSearchDetailsViewModel){
+
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+
+    LaunchedEffect(currentBackStackEntry){
         jobSearchViewModel.clearData()
         jobSearchViewModel.tokenProvider = tokenProvider
     }
@@ -79,18 +83,11 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, 
                 items(filteredJobs.size) { index ->
                     val job = filteredJobs[index]
                     JobListItem(job = job){
-                        jobSearchViewModel.selectedJobId = job.id
+                        jobSearchDetailsViewModel.selectedJobId = job.id
                         navController.navigate("jobSearchDetailsScreen")
                     }
                 }
             }
         }
     }
-}
-
-@Preview(showBackground = true)
-@Composable
-fun JobSearchScreenPreview() {
-    val navController = rememberNavController()
-    JobSearchScreen(navController, tokenProvider = object : TokenProvider { override fun getToken(): String? { return null } }, jobSearchViewModel = JobSearchViewModel())
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
@@ -14,7 +14,6 @@ class JobSearchViewModel : ViewModel(){
     var success : Boolean = false
     var message : String? = null
     val jobs = mutableStateOf(emptyList<JobSearchModel>())
-    var selectedJobId : Int = 0
 
     var tokenProvider: TokenProvider? = null
     set(value) {
@@ -34,7 +33,9 @@ class JobSearchViewModel : ViewModel(){
     }
 
     fun clearData(){
-        selectedJobId = 0
+        success = false
+        message = null
+        jobs.value = emptyList()
     }
 
     fun isLoading() : Boolean{


### PR DESCRIPTION
## Što je napravljeno

- Ekran za pretraživanje poslova i ekran posla koji se odabere imaju zasebne viewmodele

![image](https://github.com/user-attachments/assets/bd6841d4-6a72-4030-a8ef-348b4f8d2856)

- Svaki put kada se na bilo koji način dolazi na ekran za pretraživanje, ekran ponovno fetcha sve poslove

![image](https://github.com/user-attachments/assets/2f412b60-323e-4e24-b717-1803510f6408)

- Isto i kada se dođe na ekran posla kojeg smo odabrali, uvijek ponovno fetcha podatke

![image](https://github.com/user-attachments/assets/9ea6ff01-15fe-457c-9115-0beb8ca12c57)

## Moguće primjedbe

- U nekom finalnom izdanju aplikacije bi vjerojatno bilo poželjnije da kada korisnik prvi put dođe na ekran za pretraživanje poslova da samo onda napravi fetch poslova, a svaki sljedeći put da korisnik mora ručno povući za osvježavanje popisa, ali probao sam to implementirati i definitivno izlazi iz scopea issuea s obzirom na story pointove, to može bit task u zadnjem sprintu