### PR TITLE
BAUF-106 zaslon o poslovima na koje radnik eka

### DIFF
--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobsForCurrentUser/SearchMyJobsForUserResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobsForCurrentUser/SearchMyJobsForUserResponse.cs
@@ -4,6 +4,7 @@ namespace BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 
 public record SearchMyJobsForUserResponse
 {
+    public bool Success { get; set; } = false;
     public List<JobWorkingModel> Jobs { get; set; } = new List<JobWorkingModel>();
     public string? Error { get; set; } = string.Empty;
 }

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobsForCurrentUser/SearchMyJobsForUserResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobsForCurrentUser/SearchMyJobsForUserResponse.cs
@@ -1,0 +1,9 @@
+﻿using DataAccessLayer.Models;
+
+namespace BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
+
+public record SearchMyJobsForUserResponse
+{
+    public List<JobWorkingModel> Jobs { get; set; } = new List<JobWorkingModel>();
+    public string? Error { get; set; } = string.Empty;
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobsForCurrentUser/SearchMyJobsForUserResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobsForCurrentUser/SearchMyJobsForUserResponse.cs
@@ -1,0 +1,10 @@
+﻿using DataAccessLayer.Models;
+
+namespace BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
+
+public class SearchMyJobsForUserResponse
+{
+    public bool Success { get; set; } = false;
+    public List<MyJobModel> Jobs { get; set; } = new List<MyJobModel>();
+    public string? Error { get; set; } = string.Empty;
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobsForCurrentUser/SearchPendingJobsForUserResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobsForCurrentUser/SearchPendingJobsForUserResponse.cs
@@ -2,7 +2,7 @@
 
 namespace BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 
-public record SearchMyJobsForUserResponse
+public record SearchPendingJobsForUserResponse
 {
     public bool Success { get; set; } = false;
     public List<JobWorkingModel> Jobs { get; set; } = new List<JobWorkingModel>();

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
@@ -2,11 +2,6 @@
 using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
 using BusinessLogicLayer.AppLogic.Jobs.GetJob;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BusinessLogicLayer.AppLogic.Jobs
 {
@@ -17,6 +12,6 @@ namespace BusinessLogicLayer.AppLogic.Jobs
         public GetJobResponse GetJob(int jobId);
         public CallWarkerToJobResponse CallWorkerToJob(CallWorkerToJobRequest request, int userId);
         public PendingInvitationResponse GetPendingInvitations(int userId);
+        public SearchMyJobsForUserResponse SearchMyJobsForUser(int userId);
     }
 }
-     

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
@@ -12,6 +12,6 @@ namespace BusinessLogicLayer.AppLogic.Jobs
         public GetJobResponse GetJob(int jobId);
         public CallWarkerToJobResponse CallWorkerToJob(CallWorkerToJobRequest request, int userId);
         public PendingInvitationResponse GetPendingInvitations(int userId);
-        public SearchMyJobsForUserResponse SearchMyJobsForUser(int userId);
+        public SearchPendingJobsForUserResponse SearchPendingJobsForUser(int userId);
     }
 }

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
@@ -13,5 +13,6 @@ namespace BusinessLogicLayer.AppLogic.Jobs
         public CallWarkerToJobResponse CallWorkerToJob(CallWorkerToJobRequest request, int userId);
         public PendingInvitationResponse GetPendingInvitations(int userId);
         public SearchPendingJobsForUserResponse SearchPendingJobsForUser(int userId);
+        public SearchMyJobsForUserResponse SearchMyJobsForUser(int userId);
     }
 }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -211,5 +211,24 @@ namespace BusinessLogicLayer.Infrastructure
 
             return response;
         }
+
+        public SearchMyJobsForUserResponse SearchMyJobsForUser(int userId)
+        {
+            var response = new SearchMyJobsForUserResponse();
+
+            try
+            {
+                var jobs = _jobRepository.GetMyJobsForUser(userId);
+                response.Jobs = jobs;
+                response.Success = true;
+            }
+            catch (Exception ex)
+            {
+                response.Error = $"Došlo je do greške prilikom dohvaćanja podataka: {ex.Message}";
+                response.Success = false;
+            }
+
+            return response;
+        }
     }
 }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -188,14 +188,14 @@ namespace BusinessLogicLayer.Infrastructure
             return response;
         }
 
-        public SearchMyJobsForUserResponse SearchMyJobsForUser(int userId)
+        public SearchPendingJobsForUserResponse SearchPendingJobsForUser(int userId)
         {
-            var response = new SearchMyJobsForUserResponse();
+            var response = new SearchPendingJobsForUserResponse();
 
             try
             {
                 var jobs = new List<JobWorkingModel>();
-                int[] statuses = [2, 3]; // Svi statusi koji upadaju u pretraživanje
+                int[] statuses = [2, 3, 4];
                 foreach (var status in statuses)
                 {
                     var foundJobsForStatus = _jobRepository.GetJobWorkingByUserAndStatus(userId, status);

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -187,5 +187,27 @@ namespace BusinessLogicLayer.Infrastructure
 
             return response;
         }
+
+        public SearchMyJobsForUserResponse SearchMyJobsForUser(int userId)
+        {
+            var response = new SearchMyJobsForUserResponse();
+
+            try
+            {
+                var jobs = new List<JobWorkingModel>();
+                int[] statuses = [2, 3]; // Svi statusi koji upadaju u pretraživanje
+                foreach (var status in statuses)
+                {
+                    var foundJobsForStatus = _jobRepository.GetJobWorkingByUserAndStatus(userId, status);
+                    jobs.AddRange(foundJobsForStatus);
+                }
+                response.Jobs = jobs;
+            } catch (Exception ex)
+            {
+                response.Error = $"Došlo je do greške prilikom dohvaćanja podataka: {ex.Message}";
+            }
+
+            return response;
+        }
     }
 }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -202,9 +202,11 @@ namespace BusinessLogicLayer.Infrastructure
                     jobs.AddRange(foundJobsForStatus);
                 }
                 response.Jobs = jobs;
+                response.Success = true;
             } catch (Exception ex)
             {
                 response.Error = $"Došlo je do greške prilikom dohvaćanja podataka: {ex.Message}";
+                response.Success = false;
             }
 
             return response;

--- a/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
+++ b/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
@@ -43,5 +43,13 @@ namespace DataAccessLayer.AppLogic
         /// <param name="jobId"></param>
         /// <returns></returns>
         public JobModel GetJob(int jobId);
+
+        /// <summary>
+        /// Dohvaća job i working po korisniku i statusu
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <param name="statusId"></param>
+        /// <returns></returns>
+        public List<JobWorkingModel> GetJobWorkingByUserAndStatus(int userId, int statusId);
     }
 }

--- a/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
+++ b/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
@@ -51,5 +51,12 @@ namespace DataAccessLayer.AppLogic
         /// <param name="statusId"></param>
         /// <returns></returns>
         public List<JobWorkingModel> GetJobWorkingByUserAndStatus(int userId, int statusId);
+
+        /// <summary>
+        /// Dohvaća poslove kojima je korisnik vlasnik ili je primljen na njih
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <returns></returns>
+        public List<MyJobModel> GetMyJobsForUser(int userId);
     }
 }

--- a/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
@@ -275,6 +275,7 @@ namespace DataAccessLayer.Infrastructure
                 OR j.id IN (
 	                SELECT job_id FROM working
 	                WHERE worker_id = @userId
+                    AND working_status_id = 4
                 );";
 
             var parameters = new Dictionary<string, object>

--- a/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
@@ -208,5 +208,49 @@ namespace DataAccessLayer.Infrastructure
                 return null;
             }
         }
+
+        /// <summary>
+        /// Dohvaća job i working po korisniku i statusu
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <param name="statusId"></param>
+        /// <returns></returns>
+        public List<JobWorkingModel> GetJobWorkingByUserAndStatus(int userId, int statusId)
+        {
+            string query = @"
+            SELECT j.id as job_id, w.id as working_id, j.title, j.location, ws.id as status_id, ws.status, w.worker_id
+            FROM job j LEFT JOIN working w
+            ON j.id = w.job_id
+            JOIN working_status ws
+            ON ws.id = w.working_status_id
+            WHERE w.worker_id = @userId
+            AND ws.id = @statusId;
+            ";
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "@userId", userId },
+                { "@statusId", statusId }
+            };
+
+            using (var reader = _db.ExecuteReader(query, parameters))
+            {
+                var jobs = new List<JobWorkingModel>();
+                while (reader.Read())
+                {
+                    jobs.Add(new JobWorkingModel
+                    {
+                        JobId = (int)reader["job_id"],
+                        WorkingId = (int)reader["working_id"],
+                        WorkerId = reader["worker_id"] as int?,
+                        StatusId = (int)reader["status_id"],
+                        Status = (string)reader["status"],
+                        Title = (string)reader["title"],
+                        Location = (string)reader["location"]
+                    });
+                }
+                return jobs;
+            }
+        }
     }
 }

--- a/Software/Backend/DataAccessLayer/Models/JobWorkingModel.cs
+++ b/Software/Backend/DataAccessLayer/Models/JobWorkingModel.cs
@@ -1,0 +1,12 @@
+﻿namespace DataAccessLayer.Models;
+
+public record JobWorkingModel
+{
+    public int JobId { get; set; }
+    public int WorkingId { get; set; }
+    public int? WorkerId { get; set; }
+    public int StatusId { get; set; }
+    public string Status { get; set; }
+    public string Title { get; set; }
+    public string Location { get; set; }
+}

--- a/Software/Backend/DataAccessLayer/Models/MyJobModel.cs
+++ b/Software/Backend/DataAccessLayer/Models/MyJobModel.cs
@@ -1,0 +1,19 @@
+﻿namespace DataAccessLayer.Models;
+
+/// <summary>
+/// Sadrži informacije o poslu korisnika ili posllovima na koje je dodan
+/// </summary>
+public record MyJobModel
+{
+    public int Id { get; set; }
+    public int EmployerId { get; set; }
+    public int JobStatusId { get; set; }
+    public string JobStatus { get; set; }
+    public string Title { get; set; }
+    public string Description { get; set; }
+    public bool AllowWorkerInvite { get; set; }
+    public string Location { get; set; }
+    public decimal? Lat { get; set; }
+    public decimal? Lng { get; set; }
+    public bool UserIsEmployer { get; set; }
+}

--- a/Software/Backend/WebApi/Controllers/JobController.cs
+++ b/Software/Backend/WebApi/Controllers/JobController.cs
@@ -141,4 +141,23 @@ public class JobController : ControllerBase
 
         return jobs;
     }
+
+    [HttpGet("SearchMyJobsForUser")]
+    [Authorize]
+    public ActionResult<SearchMyJobsForUserResponse> SearchMyJobsForUser()
+    {
+        var userIdFromJwt = HttpContext.Items["UserId"] as int?;
+
+        if (userIdFromJwt == null)
+        {
+            return Unauthorized(new GetJobResponse()
+            {
+                Error = "Ne možete pristupiti tom resursu!"
+            });
+        }
+
+        var jobs = _jobService.SearchMyJobsForUser(userIdFromJwt.Value);
+
+        return jobs;
+    }
 }

--- a/Software/Backend/WebApi/Controllers/JobController.cs
+++ b/Software/Backend/WebApi/Controllers/JobController.cs
@@ -123,4 +123,22 @@ public class JobController : ControllerBase
         return jobs;
     }
 
+    [HttpGet("SearchMyJobsForUser")]
+    [Authorize]
+    public ActionResult<SearchMyJobsForUserResponse> SearchMyJobsForUser()
+    {
+        var userIdFromJwt = HttpContext.Items["UserId"] as int?;
+
+        if (userIdFromJwt == null)
+        {
+            return Unauthorized(new GetJobResponse()
+            {
+                Error = "Ne možete pristupiti tom resursu!"
+            });
+        }
+
+        var jobs = _jobService.SearchMyJobsForUser(userIdFromJwt.Value);
+
+        return jobs;
+    }
 }

--- a/Software/Backend/WebApi/Controllers/JobController.cs
+++ b/Software/Backend/WebApi/Controllers/JobController.cs
@@ -123,9 +123,9 @@ public class JobController : ControllerBase
         return jobs;
     }
 
-    [HttpGet("SearchMyJobsForUser")]
+    [HttpGet("SearchPendingJobsForUser")]
     [Authorize]
-    public ActionResult<SearchMyJobsForUserResponse> SearchMyJobsForUser()
+    public ActionResult<SearchPendingJobsForUserResponse> SearchPendingJobsForUser()
     {
         var userIdFromJwt = HttpContext.Items["UserId"] as int?;
 
@@ -137,7 +137,7 @@ public class JobController : ControllerBase
             });
         }
 
-        var jobs = _jobService.SearchMyJobsForUser(userIdFromJwt.Value);
+        var jobs = _jobService.SearchPendingJobsForUser(userIdFromJwt.Value);
 
         return jobs;
     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -36,6 +36,7 @@ import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchScreen
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchViewModel
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
 import hr.foi.air.baufind.ui.screens.MyJobsScreen.MyJobsScreen
+import hr.foi.air.baufind.ui.screens.MyJobsScreen.MyJobsViewModel
 import hr.foi.air.baufind.ui.screens.Settings.SettingsScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.EditProfileScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.ReviewsScreen
@@ -56,6 +57,7 @@ class MainActivity : ComponentActivity() {
         val jobViewModel = JobViewModel()
         val jobSearchViewModel = JobSearchViewModel()
         val jobSearchDetailsViewModel = JobSearchDetailsViewModel()
+        val myJobsViewModel = MyJobsViewModel()
         setContent {
             val navController = rememberNavController()
             val currentRoute = navController
@@ -145,7 +147,7 @@ class MainActivity : ComponentActivity() {
                             composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel, tokenProvider) }
 
                             composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider, jobSearchViewModel, jobSearchDetailsViewModel) }
-                            composable("myJobsScreen") { MyJobsScreen(navController, tokenProvider) }
+                            composable("myJobsScreen") { MyJobsScreen(navController, tokenProvider, myJobsViewModel) }
                             composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchDetailsViewModel) }
                             composable("settingsScreen") { SettingsScreen(navController) }
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -35,6 +35,7 @@ import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchDetailsViewModel
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchScreen
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchViewModel
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
+import hr.foi.air.baufind.ui.screens.MyJobsScreen.MyJobsScreen
 import hr.foi.air.baufind.ui.screens.Settings.SettingsScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.EditProfileScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.ReviewsScreen
@@ -70,7 +71,8 @@ class MainActivity : ComponentActivity() {
                                 "jobDetailsScreen",
                                 "jobSearchScreen",
                                 "jobSearchDetailsScreen",
-                                "settingsScreen"
+                                "settingsScreen",
+                                "myJobsScreen"
                             )
                         ) {
                             BottomNavigationBar(navController = navController)
@@ -143,6 +145,7 @@ class MainActivity : ComponentActivity() {
                             composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel, tokenProvider) }
 
                             composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider, jobSearchViewModel, jobSearchDetailsViewModel) }
+                            composable("myJobsScreen") { MyJobsScreen(navController, tokenProvider) }
                             composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchDetailsViewModel) }
                             composable("settingsScreen") { SettingsScreen(navController) }
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -19,12 +19,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.google.gson.Gson
-import hr.foi.air.baufind.core.map.MapProvider
-import hr.foi.air.baufind.example_map.ExampleMapProvider
-import hr.foi.air.baufind.google_map.GoogleMapProvider
-import hr.foi.air.baufind.helpers.MapHelper
 import hr.foi.air.baufind.navigation.BottomNavigationBar
-import hr.foi.air.baufind.open_street_map.OpenStreetMapProvider
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobAddSkillsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobPositionsLocationScreen
@@ -37,6 +32,8 @@ import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchViewModel
 import hr.foi.air.baufind.ui.screens.LoginScreen.LoginScreen
 import hr.foi.air.baufind.ui.screens.MyJobsScreen.MyJobsScreen
 import hr.foi.air.baufind.ui.screens.MyJobsScreen.MyJobsViewModel
+import hr.foi.air.baufind.ui.screens.PendingJobsScreen.PendingJobsScreen
+import hr.foi.air.baufind.ui.screens.PendingJobsScreen.PendingJobsViewModel
 import hr.foi.air.baufind.ui.screens.Settings.SettingsScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.EditProfileScreen
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.ReviewsScreen
@@ -57,6 +54,7 @@ class MainActivity : ComponentActivity() {
         val jobViewModel = JobViewModel()
         val jobSearchViewModel = JobSearchViewModel()
         val jobSearchDetailsViewModel = JobSearchDetailsViewModel()
+        val pendingJobsViewModel = PendingJobsViewModel()
         val myJobsViewModel = MyJobsViewModel()
         setContent {
             val navController = rememberNavController()
@@ -74,6 +72,7 @@ class MainActivity : ComponentActivity() {
                                 "jobSearchScreen",
                                 "jobSearchDetailsScreen",
                                 "settingsScreen",
+                                "pendingJobsScreen",
                                 "myJobsScreen"
                             )
                         ) {
@@ -147,6 +146,7 @@ class MainActivity : ComponentActivity() {
                             composable("jobAddSkillsScreen") { JobAddSkillsScreen(navController, jobViewModel, tokenProvider) }
 
                             composable("jobSearchScreen") { JobSearchScreen(navController, tokenProvider, jobSearchViewModel, jobSearchDetailsViewModel) }
+                            composable("pendingJobsScreen") { PendingJobsScreen(navController, tokenProvider, pendingJobsViewModel) }
                             composable("myJobsScreen") { MyJobsScreen(navController, tokenProvider, myJobsViewModel) }
                             composable("jobSearchDetailsScreen") { JobSearchDetailsScreen(navController, tokenProvider, jobSearchDetailsViewModel) }
                             composable("settingsScreen") { SettingsScreen(navController) }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/navigation/BottomNavigationBar.kt
@@ -2,6 +2,7 @@ package hr.foi.air.baufind.navigation
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
@@ -25,6 +26,9 @@ fun BottomNavigationBar(navController: NavController) {
             BottomNavItem(
             route = "jobSearchScreen",
             icon = IconType.Vector(imageVector = Icons.Default.Search), label = "Search jobs"),
+            BottomNavItem(
+            route = "myJobsScreen",
+            icon = IconType.Vector(imageVector = Icons.Default.Home), label = "My jobs"),
             BottomNavItem(
             route = "userProfileScreen",
             icon = IconType.Vector(imageVector = Icons.Default.Person), label = "Profile"),

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/JobService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/JobService.kt
@@ -45,4 +45,29 @@ class JobService(){
             )
         }
     }
+
+    suspend fun getMyJobsForUser(tokenProvider: TokenProvider): MyJobsForUserResponse {
+        val service = NetworkService.createJobService(tokenProvider)
+
+        try {
+            val response = service.getMyJobsForUser()
+            if (!response.success) {
+                return MyJobsForUserResponse(
+                    false,
+                    response.error
+                )
+            }
+
+            return MyJobsForUserResponse(
+                true,
+                null,
+                response.jobs
+            )
+        } catch (e: Exception) {
+            return MyJobsForUserResponse(
+                false,
+                e.message
+            )
+        }
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/JobService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/JobService.kt
@@ -70,4 +70,29 @@ class JobService(){
             )
         }
     }
+
+    suspend fun getMyJobsForUser(tokenProvider: TokenProvider): MyJobsForUserResponse {
+        val service = NetworkService.createJobService(tokenProvider)
+
+        try {
+            val response = service.getMyJobsForUser()
+            if (!response.success) {
+                return MyJobsForUserResponse(
+                    false,
+                    response.error
+                )
+            }
+
+            return MyJobsForUserResponse(
+                true,
+                null,
+                response.jobs
+            )
+        } catch (e: Exception) {
+            return MyJobsForUserResponse(
+                false,
+                e.message
+            )
+        }
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/JobService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/JobService.kt
@@ -46,25 +46,25 @@ class JobService(){
         }
     }
 
-    suspend fun getMyJobsForUser(tokenProvider: TokenProvider): MyJobsForUserResponse {
+    suspend fun getPendingJobsForUser(tokenProvider: TokenProvider): PendingJobsForUserResponse {
         val service = NetworkService.createJobService(tokenProvider)
 
         try {
-            val response = service.getMyJobsForUser()
+            val response = service.getPendingJobsForUser()
             if (!response.success) {
-                return MyJobsForUserResponse(
+                return PendingJobsForUserResponse(
                     false,
                     response.error
                 )
             }
 
-            return MyJobsForUserResponse(
+            return PendingJobsForUserResponse(
                 true,
                 null,
                 response.jobs
             )
         } catch (e: Exception) {
-            return MyJobsForUserResponse(
+            return PendingJobsForUserResponse(
                 false,
                 e.message
             )

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/MyJobsForUserResponse.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/MyJobsForUserResponse.kt
@@ -1,0 +1,9 @@
+package hr.foi.air.baufind.service.JobService
+
+import hr.foi.air.baufind.ws.model.MyJobModel
+
+data class MyJobsForUserResponse (
+    val success: Boolean,
+    val error: String? = null,
+    val jobs: List<MyJobModel> = listOf()
+)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/MyJobsForUserResponse.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/MyJobsForUserResponse.kt
@@ -1,0 +1,9 @@
+package hr.foi.air.baufind.service.JobService
+
+import hr.foi.air.baufind.ws.model.JobWorkingModel
+
+data class MyJobsForUserResponse(
+    val success: Boolean,
+    val error: String? = null,
+    val jobs: List<JobWorkingModel> = listOf()
+)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/PendingJobsForUserResponse.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/PendingJobsForUserResponse.kt
@@ -2,7 +2,7 @@ package hr.foi.air.baufind.service.JobService
 
 import hr.foi.air.baufind.ws.model.JobWorkingModel
 
-data class MyJobsForUserResponse(
+data class PendingJobsForUserResponse(
     val success: Boolean,
     val error: String? = null,
     val jobs: List<JobWorkingModel> = listOf()

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/JobWorkingListItem.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/JobWorkingListItem.kt
@@ -1,0 +1,52 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import hr.foi.air.baufind.ws.model.JobWorkingModel
+
+@Composable
+fun JobWorkingListItem(
+    job: JobWorkingModel,
+    onItemClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.LightGray)
+            .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
+            .padding(8.dp)
+            .clickable { onItemClick() },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ){
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Naslov:", modifier = Modifier.weight(0.3f))
+                Text(text = job.title, modifier = Modifier.weight(0.7f))
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Status:", modifier = Modifier.weight(0.3f))
+                Text(text = job.status, modifier = Modifier.weight(0.7f))
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Lokacija:", modifier = Modifier.weight(0.3f))
+                Text(text = job.location, modifier = Modifier.weight(0.7f))
+            }
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/MyJobListItem.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/MyJobListItem.kt
@@ -1,0 +1,57 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import hr.foi.air.baufind.ws.model.MyJobModel
+
+@Composable
+fun MyJobListItem(
+    job: MyJobModel,
+    onItemClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.LightGray)
+            .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
+            .padding(8.dp)
+            .clickable { onItemClick() },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ){
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Naslov:", modifier = Modifier.weight(0.3f))
+                Text(text = job.title, modifier = Modifier.weight(0.7f))
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Status posla:", modifier = Modifier.weight(0.3f))
+                Text(text = job.jobStatus, modifier = Modifier.weight(0.7f))
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Lokacija:", modifier = Modifier.weight(0.3f))
+                Text(text = job.location, modifier = Modifier.weight(0.7f))
+            }
+            if (job.userIsEmployer) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(text = "Vi ste vlasnik posla", modifier = Modifier.weight(0.3f))
+                }
+            }
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
@@ -1,14 +1,101 @@
 package hr.foi.air.baufind.ui.screens.MyJobsScreen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import hr.foi.air.baufind.R
 import hr.foi.air.baufind.ws.network.TokenProvider
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyJobsScreen(
     navController: NavController,
     tokenProvider: TokenProvider
 ) {
-    Text(text = "Zaslon mojih poslova!");
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+
+    val viewModel: MyJobsViewModel = MyJobsViewModel()
+    LaunchedEffect(currentBackStackEntry) {
+        viewModel.tokenProvider = tokenProvider
+    }
+
+    Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = remember { SnackbarHostState() })
+        },
+        topBar = {
+            CenterAlignedTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = {
+                    Text(
+                        "My jobs",
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.ExtraBold,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { }) { // TODO: odvede na zaslon
+                        Icon(
+                            painter = painterResource(R.drawable.baseline_history_24),
+                            contentDescription = "History",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.mediumTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.background)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Text("Ja radim!")
+        }
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
@@ -1,15 +1,162 @@
 package hr.foi.air.baufind.ui.screens.MyJobsScreen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import hr.foi.air.baufind.R
+import hr.foi.air.baufind.ui.components.JobWorkingListItem
+import hr.foi.air.baufind.ui.components.MyJobListItem
 import hr.foi.air.baufind.ws.network.TokenProvider
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyJobsScreen(
     navController: NavController,
     tokenProvider: TokenProvider,
     viewModel: MyJobsViewModel
 ) {
-    Text("Ja sam zaslon koji radi!")
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+
+    val isLoading by viewModel.isLoading
+    LaunchedEffect(currentBackStackEntry) {
+        viewModel.clearData()
+        viewModel.tokenProvider = tokenProvider
+    }
+
+    Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = remember { SnackbarHostState() })
+        },
+        topBar = {
+            CenterAlignedTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = {
+                    Text(
+                        "My jobs",
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.ExtraBold,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { }) { // TODO: odvede na zaslon
+                        Icon(
+                            painter = painterResource(R.drawable.baseline_history_24),
+                            contentDescription = "History",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.mediumTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            if (isLoading) {
+                Text(text = "Učitavam...")
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(22.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ){
+                    items(viewModel.myCreatedJobs.value.size) { index ->
+                        if (index == 0) {
+                            Text(
+                                text = "Moji poslovi",
+                                modifier = Modifier
+                                    .align(Alignment.Start)
+                                    .padding(
+                                        bottom = 8.dp
+                                    ),
+                                fontSize = 20.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+
+                        val job = viewModel.myCreatedJobs.value[index]
+                        MyJobListItem(job = job){
+                            // TODO: odvede na zaslon MOG posla
+                        }
+                    }
+                    items(viewModel.jobsImOn.value.size) { index ->
+                        if (index == 0) {
+                            HorizontalDivider(
+                                modifier = Modifier
+                                    .padding(
+                                        top = 20.dp
+                                    ),
+                                thickness = 2.dp
+                            )
+                            Text(
+                                text = "Poslovi na kojima radim",
+                                modifier = Modifier
+                                    .align(Alignment.Start)
+                                    .padding(
+                                        bottom = 8.dp
+                                    ),
+                                fontSize = 20.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+
+                        val job = viewModel.jobsImOn.value[index]
+                        MyJobListItem(job = job){
+                            // TODO: odvede na zaslon posla na kojemu radim ili čekam
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
@@ -1,120 +1,15 @@
 package hr.foi.air.baufind.ui.screens.MyJobsScreen
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
-import androidx.navigation.compose.currentBackStackEntryAsState
-import hr.foi.air.baufind.R
-import hr.foi.air.baufind.ui.components.JobWorkingListItem
 import hr.foi.air.baufind.ws.network.TokenProvider
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyJobsScreen(
     navController: NavController,
     tokenProvider: TokenProvider,
     viewModel: MyJobsViewModel
 ) {
-    val currentBackStackEntry by navController.currentBackStackEntryAsState()
-
-    val isLoading by viewModel.isLoading
-    LaunchedEffect(currentBackStackEntry) {
-        viewModel.clearData()
-        viewModel.tokenProvider = tokenProvider
-    }
-
-    Scaffold(
-        snackbarHost = {
-            SnackbarHost(hostState = remember { SnackbarHostState() })
-        },
-        topBar = {
-            CenterAlignedTopAppBar(
-                modifier = Modifier.fillMaxWidth(),
-                title = {
-                    Text(
-                        "My jobs",
-                        fontWeight = FontWeight.Bold,
-                        style = MaterialTheme.typography.titleMedium.copy(
-                            fontWeight = FontWeight.ExtraBold,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back",
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                },
-                actions = {
-                    IconButton(onClick = { }) { // TODO: odvede na zaslon
-                        Icon(
-                            painter = painterResource(R.drawable.baseline_history_24),
-                            contentDescription = "History",
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.mediumTopAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                    titleContentColor = MaterialTheme.colorScheme.primary,
-                    navigationIconContentColor = MaterialTheme.colorScheme.primary
-                )
-            )
-        }
-    ) { paddingValues ->
-        Column(
-            modifier = Modifier
-                .padding(paddingValues)
-                .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.background)
-        ) {
-            if (isLoading) {
-                Text(text = "Učitavam...")
-            } else {
-                LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(22.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ){
-                    items(viewModel.jobs.value.size) { index ->
-                        val job = viewModel.jobs.value[index]
-                        JobWorkingListItem(job = job){
-                            // TODO: odvede na zaslon posla
-                        }
-                    }
-                }
-            }
-        }
-    }
+    Text("Ja sam zaslon koji radi!")
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
@@ -1,11 +1,11 @@
 package hr.foi.air.baufind.ui.screens.MyJobsScreen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -21,27 +21,30 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import hr.foi.air.baufind.R
+import hr.foi.air.baufind.ui.components.JobWorkingListItem
 import hr.foi.air.baufind.ws.network.TokenProvider
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyJobsScreen(
     navController: NavController,
-    tokenProvider: TokenProvider
+    tokenProvider: TokenProvider,
+    viewModel: MyJobsViewModel
 ) {
     val currentBackStackEntry by navController.currentBackStackEntryAsState()
 
-    val viewModel: MyJobsViewModel = MyJobsViewModel()
+    val isLoading by viewModel.isLoading
     LaunchedEffect(currentBackStackEntry) {
+        viewModel.clearData()
         viewModel.tokenProvider = tokenProvider
     }
 
@@ -93,9 +96,25 @@ fun MyJobsScreen(
                 .padding(paddingValues)
                 .fillMaxWidth()
                 .background(MaterialTheme.colorScheme.background)
-                .verticalScroll(rememberScrollState())
         ) {
-            Text("Ja radim!")
+            if (isLoading) {
+                Text(text = "Učitavam...")
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(22.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ){
+                    items(viewModel.jobs.value.size) { index ->
+                        val job = viewModel.jobs.value[index]
+                        JobWorkingListItem(job = job){
+                            // TODO: odvede na zaslon posla
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
@@ -1,0 +1,14 @@
+package hr.foi.air.baufind.ui.screens.MyJobsScreen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavController
+import hr.foi.air.baufind.ws.network.TokenProvider
+
+@Composable
+fun MyJobsScreen(
+    navController: NavController,
+    tokenProvider: TokenProvider
+) {
+    Text(text = "Zaslon mojih poslova!");
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
@@ -1,0 +1,7 @@
+package hr.foi.air.baufind.ui.screens.MyJobsScreen
+
+import androidx.lifecycle.ViewModel
+
+class MyJobsViewModel : ViewModel() {
+
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 
 class MyJobsViewModel : ViewModel() {
     var success : Boolean = false
+    var isLoading = mutableStateOf(false)
     val jobs = mutableStateOf(emptyList<JobWorkingModel>())
 
     var tokenProvider: TokenProvider? = null
@@ -21,10 +22,13 @@ class MyJobsViewModel : ViewModel() {
 
     private fun loadJobs(tokenProvider: TokenProvider) {
         viewModelScope.launch {
+            isLoading.value = true
             val service = JobService()
             val response = service.getMyJobsForUser(tokenProvider)
             success = response.success
             jobs.value = response.jobs
+            isLoading.value = false
+            Log.i("MyJobsViewModel", jobs.value.toString())
         }
     }
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
@@ -1,6 +1,43 @@
 package hr.foi.air.baufind.ui.screens.MyJobsScreen
 
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import hr.foi.air.baufind.service.JobService.JobService
+import hr.foi.air.baufind.ws.model.MyJobModel
+import hr.foi.air.baufind.ws.network.TokenProvider
+import kotlinx.coroutines.launch
 
 class MyJobsViewModel : ViewModel() {
+    var success: Boolean = false
+    var isLoading = mutableStateOf(false)
+    val jobs = mutableStateOf(emptyList<MyJobModel>())
+    val myCreatedJobs = mutableStateOf(emptyList<MyJobModel>())
+    val jobsImOn = mutableStateOf(emptyList<MyJobModel>())
+
+    var tokenProvider: TokenProvider? = null
+    set(value) {
+        field = value
+        value?.let { loadJobs(it) }
+    }
+
+    private fun loadJobs(tokenProvider: TokenProvider) {
+        viewModelScope.launch {
+            isLoading.value = true
+            val service = JobService()
+            val response = service.getMyJobsForUser(tokenProvider)
+            success = response.success
+            jobs.value = response.jobs
+            myCreatedJobs.value = jobs.value.filter { it.userIsEmployer }
+            jobsImOn.value = jobs.value.filter { !it.userIsEmployer }
+            isLoading.value = false
+        }
+    }
+
+    fun clearData() {
+        success = false
+        jobs.value = emptyList()
+        myCreatedJobs.value = emptyList()
+        jobsImOn.value = emptyList()
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
@@ -1,39 +1,6 @@
 package hr.foi.air.baufind.ui.screens.MyJobsScreen
 
-import android.util.Log
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import hr.foi.air.baufind.service.JobService.JobService
-import hr.foi.air.baufind.ws.model.JobWorkingModel
-import hr.foi.air.baufind.ws.network.TokenProvider
-import kotlinx.coroutines.launch
 
 class MyJobsViewModel : ViewModel() {
-    var success : Boolean = false
-    var isLoading = mutableStateOf(false)
-    val jobs = mutableStateOf(emptyList<JobWorkingModel>())
-
-    var tokenProvider: TokenProvider? = null
-    set(value) {
-        field = value
-        value?.let { loadJobs(it) }
-    }
-
-    private fun loadJobs(tokenProvider: TokenProvider) {
-        viewModelScope.launch {
-            isLoading.value = true
-            val service = JobService()
-            val response = service.getMyJobsForUser(tokenProvider)
-            success = response.success
-            jobs.value = response.jobs
-            isLoading.value = false
-            Log.i("MyJobsViewModel", jobs.value.toString())
-        }
-    }
-
-    fun clearData() {
-        success = false
-        jobs.value = emptyList()
-    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsViewModel.kt
@@ -1,7 +1,35 @@
 package hr.foi.air.baufind.ui.screens.MyJobsScreen
 
+import android.util.Log
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import hr.foi.air.baufind.service.JobService.JobService
+import hr.foi.air.baufind.ws.model.JobWorkingModel
+import hr.foi.air.baufind.ws.network.TokenProvider
+import kotlinx.coroutines.launch
 
 class MyJobsViewModel : ViewModel() {
+    var success : Boolean = false
+    val jobs = mutableStateOf(emptyList<JobWorkingModel>())
 
+    var tokenProvider: TokenProvider? = null
+    set(value) {
+        field = value
+        value?.let { loadJobs(it) }
+    }
+
+    private fun loadJobs(tokenProvider: TokenProvider) {
+        viewModelScope.launch {
+            val service = JobService()
+            val response = service.getMyJobsForUser(tokenProvider)
+            success = response.success
+            jobs.value = response.jobs
+        }
+    }
+
+    fun clearData() {
+        success = false
+        jobs.value = emptyList()
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsScreen.kt
@@ -1,0 +1,120 @@
+package hr.foi.air.baufind.ui.screens.PendingJobsScreen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import hr.foi.air.baufind.R
+import hr.foi.air.baufind.ui.components.JobWorkingListItem
+import hr.foi.air.baufind.ws.network.TokenProvider
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PendingJobsScreen(
+    navController: NavController,
+    tokenProvider: TokenProvider,
+    viewModel: PendingJobsViewModel
+) {
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+
+    val isLoading by viewModel.isLoading
+    LaunchedEffect(currentBackStackEntry) {
+        viewModel.clearData()
+        viewModel.tokenProvider = tokenProvider
+    }
+
+    Scaffold(
+        snackbarHost = {
+            SnackbarHost(hostState = remember { SnackbarHostState() })
+        },
+        topBar = {
+            CenterAlignedTopAppBar(
+                modifier = Modifier.fillMaxWidth(),
+                title = {
+                    Text(
+                        "Pending jobs",
+                        fontWeight = FontWeight.Bold,
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontWeight = FontWeight.ExtraBold,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { }) { // TODO: odvede na zaslon
+                        Icon(
+                            painter = painterResource(R.drawable.baseline_history_24),
+                            contentDescription = "History",
+                            tint = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.mediumTopAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                    titleContentColor = MaterialTheme.colorScheme.primary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.primary
+                )
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.background)
+        ) {
+            if (isLoading) {
+                Text(text = "Učitavam...")
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(22.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ){
+                    items(viewModel.jobs.value.size) { index ->
+                        val job = viewModel.jobs.value[index]
+                        JobWorkingListItem(job = job){
+                            // TODO: odvede na zaslon posla
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsScreen.kt
@@ -74,15 +74,7 @@ fun PendingJobsScreen(
                         )
                     }
                 },
-                actions = {
-                    IconButton(onClick = { }) { // TODO: odvede na zaslon
-                        Icon(
-                            painter = painterResource(R.drawable.baseline_history_24),
-                            contentDescription = "History",
-                            tint = MaterialTheme.colorScheme.primary
-                        )
-                    }
-                },
+                actions = { },
                 colors = TopAppBarDefaults.mediumTopAppBarColors(
                     containerColor = MaterialTheme.colorScheme.background,
                     titleContentColor = MaterialTheme.colorScheme.primary,

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsViewModel.kt
@@ -24,7 +24,7 @@ class PendingJobsViewModel : ViewModel() {
         viewModelScope.launch {
             isLoading.value = true
             val service = JobService()
-            val response = service.getMyJobsForUser(tokenProvider)
+            val response = service.getPendingJobsForUser(tokenProvider)
             success = response.success
             jobs.value = response.jobs
             isLoading.value = false

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsViewModel.kt
@@ -1,0 +1,39 @@
+package hr.foi.air.baufind.ui.screens.PendingJobsScreen
+
+import android.util.Log
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import hr.foi.air.baufind.service.JobService.JobService
+import hr.foi.air.baufind.ws.model.JobWorkingModel
+import hr.foi.air.baufind.ws.network.TokenProvider
+import kotlinx.coroutines.launch
+
+class PendingJobsViewModel : ViewModel() {
+    var success : Boolean = false
+    var isLoading = mutableStateOf(false)
+    val jobs = mutableStateOf(emptyList<JobWorkingModel>())
+
+    var tokenProvider: TokenProvider? = null
+    set(value) {
+        field = value
+        value?.let { loadJobs(it) }
+    }
+
+    private fun loadJobs(tokenProvider: TokenProvider) {
+        viewModelScope.launch {
+            isLoading.value = true
+            val service = JobService()
+            val response = service.getMyJobsForUser(tokenProvider)
+            success = response.success
+            jobs.value = response.jobs
+            isLoading.value = false
+            Log.i("PendingJobsViewModel", jobs.value.toString())
+        }
+    }
+
+    fun clearData() {
+        success = false
+        jobs.value = emptyList()
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/PendingJobsScreen/PendingJobsViewModel.kt
@@ -28,7 +28,6 @@ class PendingJobsViewModel : ViewModel() {
             success = response.success
             jobs.value = response.jobs
             isLoading.value = false
-            Log.i("PendingJobsViewModel", jobs.value.toString())
         }
     }
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/UserProfileScreen/UserProfileScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/UserProfileScreen/UserProfileScreen.kt
@@ -6,13 +6,15 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.net.Uri
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -53,28 +55,42 @@ import androidx.navigation.NavController
 import hr.foi.air.baufind.helpers.PictureHelper
 import hr.foi.air.baufind.service.UserProfileService.UserProfileService
 import hr.foi.air.baufind.service.jwtService.JwtService
+import hr.foi.air.baufind.ui.components.PrimaryButton
 import hr.foi.air.baufind.ui.components.Skill
 import hr.foi.air.baufind.ws.network.TokenProvider
 import kotlinx.coroutines.launch
 
 @Composable
-fun EditProfileButton(onClick: () -> Unit) {
+fun ProfileButtons(navController: NavController) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp),
         contentAlignment = Alignment.Center
     ) {
-        Button(
-            onClick = onClick,
-            colors = ButtonDefaults.buttonColors(
-                containerColor = MaterialTheme.colorScheme.secondary,
-                contentColor = MaterialTheme.colorScheme.onSecondary
-            )
-        ) {
-            Text(
-                text = "Edit Profile",
-                style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+        Row {
+            Button(
+                modifier = Modifier
+                    .height(48.dp),
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                onClick = {
+                    navController.navigate("editUserProfileScreen")
+                },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.secondary,
+                    contentColor = MaterialTheme.colorScheme.onSecondary
+                )
+            ) {
+                Text(
+                    text = "Edit Profile",
+                    style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+                )
+            }
+            PrimaryButton(
+                text = "Pending jobs",
+                onClick = {
+                    navController.navigate("pendingJobsScreen")
+                }
             )
         }
     }
@@ -224,7 +240,7 @@ fun userProfileScreen(
             ) {
                 UserProfileHeader(profile.name, profile.address ?: "N/A", PictureHelper.decodeBase64ToByteArray(profile.profilePicture))
                 if (isOwnProfile) {
-                    EditProfileButton(onClick = { navController.navigate("editUserProfileScreen") })
+                    ProfileButtons(navController)
                 }
                 UserProfileContactInformation(profile.address ?: "N/A", profile.phone ?: "N/A", profile.email)
                 UserSkillSection(profile.skills.orEmpty().map { skill -> Skill(skill.id, skill.title) })

--- a/Software/Frontend/app/src/main/res/drawable/baseline_history_24.xml
+++ b/Software/Frontend/app/src/main/res/drawable/baseline_history_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L6,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z"/>
+    
+</vector>

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/JobWorkingModel.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/JobWorkingModel.kt
@@ -1,0 +1,11 @@
+package hr.foi.air.baufind.ws.model
+
+data class JobWorkingModel (
+    val jobId: Int,
+    val workingId: Int,
+    val workerId: Int?,
+    val statusId: Int,
+    val status: String,
+    val title: String,
+    val location: String
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/MyJobModel.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/MyJobModel.kt
@@ -1,0 +1,15 @@
+package hr.foi.air.baufind.ws.model
+
+data class MyJobModel(
+    val id: Int,
+    val employerId: Int,
+    val jobStatusId: Int,
+    val jobStatus: String,
+    val title: String,
+    val description: String,
+    val allowWorkerInvite: Boolean,
+    val location: String,
+    val lat: Double?,
+    val lng: Double?,
+    val userIsEmployer: Boolean
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
@@ -4,6 +4,7 @@ import hr.foi.air.baufind.ws.request.JobCreateBody
 import hr.foi.air.baufind.ws.response.JobCreateResponse
 import hr.foi.air.baufind.ws.response.JobResponse
 import hr.foi.air.baufind.ws.response.JobsForCurrentUserResponse
+import hr.foi.air.baufind.ws.response.SearchMyJobsForUserResponse
 import hr.foi.air.baufind.ws.response.SearchPendingJobsForUserResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -22,4 +23,7 @@ interface JobService {
 
     @GET("/jobs/SearchPendingJobsForUser")
     suspend fun getPendingJobsForUser(): SearchPendingJobsForUserResponse
+
+    @GET("/jobs/SearchMyJobsForUser")
+    suspend fun getMyJobsForUser(): SearchMyJobsForUserResponse
 }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
@@ -4,7 +4,7 @@ import hr.foi.air.baufind.ws.request.JobCreateBody
 import hr.foi.air.baufind.ws.response.JobCreateResponse
 import hr.foi.air.baufind.ws.response.JobResponse
 import hr.foi.air.baufind.ws.response.JobsForCurrentUserResponse
-import hr.foi.air.baufind.ws.response.SearchMyJobsForUserResponse
+import hr.foi.air.baufind.ws.response.SearchPendingJobsForUserResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -20,6 +20,6 @@ interface JobService {
     @GET("/jobs/{id}")
     suspend fun getJob(@Path("id") id: Int): JobResponse
 
-    @GET("/jobs/SearchMyJobsForUser")
-    suspend fun getMyJobsForUser(): SearchMyJobsForUserResponse
+    @GET("/jobs/SearchPendingJobsForUser")
+    suspend fun getPendingJobsForUser(): SearchPendingJobsForUserResponse
 }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
@@ -4,6 +4,7 @@ import hr.foi.air.baufind.ws.request.JobCreateBody
 import hr.foi.air.baufind.ws.response.JobCreateResponse
 import hr.foi.air.baufind.ws.response.JobResponse
 import hr.foi.air.baufind.ws.response.JobsForCurrentUserResponse
+import hr.foi.air.baufind.ws.response.SearchMyJobsForUserResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -19,4 +20,6 @@ interface JobService {
     @GET("/jobs/{id}")
     suspend fun getJob(@Path("id") id: Int): JobResponse
 
+    @GET("/jobs/SearchMyJobsForUser")
+    suspend fun getMyJobsForUser(): SearchMyJobsForUserResponse
 }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/SearchMyJobsForUserResponse.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/SearchMyJobsForUserResponse.kt
@@ -1,0 +1,9 @@
+package hr.foi.air.baufind.ws.response
+
+import hr.foi.air.baufind.ws.model.JobWorkingModel
+
+data class SearchMyJobsForUserResponse(
+    val success: Boolean,
+    val jobs : List<JobWorkingModel>,
+    val error : String?
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/SearchMyJobsForUserResponse.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/SearchMyJobsForUserResponse.kt
@@ -1,0 +1,9 @@
+package hr.foi.air.baufind.ws.response
+
+import hr.foi.air.baufind.ws.model.MyJobModel
+
+data class SearchMyJobsForUserResponse (
+    val success: Boolean,
+    val jobs : List<MyJobModel>,
+    val error : String?
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/SearchPendingJobsForUserResponse.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/SearchPendingJobsForUserResponse.kt
@@ -2,7 +2,7 @@ package hr.foi.air.baufind.ws.response
 
 import hr.foi.air.baufind.ws.model.JobWorkingModel
 
-data class SearchMyJobsForUserResponse(
+data class SearchPendingJobsForUserResponse(
     val success: Boolean,
     val jobs : List<JobWorkingModel>,
     val error : String?


### PR DESCRIPTION
**Napravljen je zaslon za poslove na koje korisnik čeka (odobrenje ili prihvaćanje):**
![image](https://github.com/user-attachments/assets/ea7f9fd0-352b-44cb-ab17-a81b95dfbb94)

Dodana je i ikonica "My jobs" na navbaru prema skicama.

Pratio sam skicu na sljedećoj poveznici: https://vlovric21.atlassian.net/wiki/spaces/baufind/pages/9568439/Kao+korisnik+elim+biti+obavije+ten+o+promijenama+vezanih+uz+svoje+zahtjeve+kako+bih+znao+status+odvijanja+zahtjeva

Napravio sam novi API poziv na _/jobs/searchMyJobsForCurrentUser_, i vraćaju se poslovi, kao i nazivi statusa:
![image](https://github.com/user-attachments/assets/dea7032a-cd28-4cfe-925d-bdaa0974cd57)

Što se tiče koda, uglavnom sam se držao strukture kao i do sada, na backendu možda ima malo ponavljanja (jer postoji putanja _CheckPendingInvitations_), no ona ne vraća statuse, samo poslove, a nisam htio nju mijenjati, iako mislim da nije toliko bitno jer je rečeno za drugu provjeru da je bitno da backend radi svoj posao, a pregledavanje koda će se uglavnom raditi na frontendu.
Na frontendu sam se držao strukture, no ako mislite da je nešto krivo, ili na krivom mjestu, samo recite i popravit ću.

Još dvije stvari:
1) Napravio sam samo zaslon s popisom, bez da se može otvoriti posao i bez da se može kliknuti na ikonicu povijesti posla, **da napravim i to? Ako da, recite pa ću odmah na ovom PR-u napraviti.**
2) Napravio sam da se na karticama posla za status ispišu vrijednosti za taj status iz baze (tablica _working status_):
![image](https://github.com/user-attachments/assets/b1d9324d-2160-4ac2-8e5b-5248f64ff288)
**Da to promijenim u bazi (nazive), ili da na backendu prema ID-u nekako ja napišem status ručno?**