### PR TITLE
Bauf 95 filtriranje poslova po zupanijama

### DIFF
--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchScreen.kt
@@ -3,8 +3,10 @@ package hr.foi.air.baufind.ui.screens.JobSearchScreen
 import android.content.Context
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,7 +18,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -32,6 +36,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -59,8 +64,7 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, 
     var selectedCounty by remember { mutableStateOf<String?>(null) }
     var showCountyBottomSheet by remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState()
-    val coroutineScope = rememberCoroutineScope()
-    var searchQuery by remember { mutableStateOf(TextFieldValue("")) }
+    var searchQuery by remember { mutableStateOf("") }
 
     val allJobs = jobSearchViewModel.jobs.value
 
@@ -76,7 +80,7 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, 
 
     val croatianCounties = jobSearchViewModel.croatianCounties
     val filteredCounties = croatianCounties.filter{
-        it.contains(searchQuery.text, ignoreCase = true)
+        it.contains(searchQuery, ignoreCase = true)
     }
 
     Column(
@@ -113,32 +117,35 @@ fun JobSearchScreen(navController: NavController, tokenProvider: TokenProvider, 
                         .padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp)
                 ){
-                    BasicTextField(
+                    OutlinedTextField(
                         value = searchQuery,
                         onValueChange = { searchQuery = it },
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(8.dp),
-                        decorationBox = { innerTextField ->
-                            if(searchQuery.text.isEmpty()){
-                                Text("Pretraži županiju")
-                            }
-                            innerTextField()
-                        }
+                        placeholder = { Text("Pretraži županiju")},
+                        singleLine = true,
+                        maxLines = 1
                     )
-                    LazyColumn {
-                        items(filteredCounties.size) { index ->
-                            val county = filteredCounties[index]
-                            Text(
-                                text = county,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(8.dp)
-                                    .clickable {
-                                        selectedCounty = county
-                                        showCountyBottomSheet = false
-                                    }
-                            )
+                    Box(modifier = Modifier.fillMaxWidth()){
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(bottom = 32.dp)
+                        ) {
+                            items(filteredCounties.size) { index ->
+                                val county = filteredCounties[index]
+                                Text(
+                                    text = county,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(8.dp)
+                                        .clickable {
+                                            selectedCounty = county
+                                            showCountyBottomSheet = false
+                                        }
+                                )
+                            }
                         }
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobSearchScreen/JobSearchViewModel.kt
@@ -15,6 +15,37 @@ class JobSearchViewModel : ViewModel(){
     var message : String? = null
     val jobs = mutableStateOf(emptyList<JobSearchModel>())
 
+    private val countyMap = mapOf(
+        "Varaždin County" to "Varaždinska županija",
+        "Zagreb County" to "Zagrebačka županija",
+        "Krapina-Zagorje County" to "Krapinsko-zagorska županija",
+        "Sisak-Moslavina County" to "Sisačko-moslavačka županija",
+        "Karlovac County" to "Karlovačka županija",
+        "Koprivnica-Križevci County" to "Koprivničko-križevačka županija",
+        "Bjelovar-Bilogora County" to "Bjelovarsko-bilogorska županija",
+        "Primorje-Gorski Kotar County" to "Primorsko-goranska županija",
+        "Lika-Senj County" to "Ličko-senjska županija",
+        "Virovitica-Podravina County" to "Virovitičko-podravska županija",
+        "Požega-Slavonia County" to "Požeško-slavonska županija",
+        "Brod-Posavina County" to "Brodsko-posavska županija",
+        "Zadar County" to "Zadarska županija",
+        "Osijek-Baranja County" to "Osječko-baranjska županija",
+        "Šibenik-Knin County" to "Šibensko-kninska županija",
+        "Vukovar-Srijem County" to "Vukovarsko-srijemska županija",
+        "Split-Dalmatia County" to "Splitsko-dalmatinska županija",
+        "Istria County" to "Istarska županija",
+        "Dubrovnik-Neretva County" to "Dubrovačko-neretvanska županija",
+        "Međimurje County" to "Međimurska županija",
+        "City of Zagreb" to "Grad Zagreb"
+    )
+
+    val croatianCounties: List<String>
+        get() = countyMap.values.toList()
+
+    fun getEnglishCounty(croatianName: String): String?{
+        return countyMap.entries.firstOrNull { it.value == croatianName }?.key
+    }
+
     var tokenProvider: TokenProvider? = null
     set(value) {
         field = value


### PR DESCRIPTION
## Što je napravljeno

- Napravljeno je filtriranje poslova po županijama Republike Hrvatske
- Pritiskom na gumb "Odaberite županiju" korisnik dobiva popis svih županija koji može pretraživati
- Kada odabere županiju onda vidi samo poslove iz te županije i dobiva gumb da očisti odabir

![image](https://github.com/user-attachments/assets/3254dffe-eb98-471a-b6ed-d80f2e921b02)

![image](https://github.com/user-attachments/assets/7f944988-51a7-4b48-abcd-f8b06470d02f)

![image](https://github.com/user-attachments/assets/bfa4a66a-3203-43ab-bc04-3a22ac94877b)

![image](https://github.com/user-attachments/assets/339542d6-18ff-44d9-bc52-2815d308bf32)

## Kako je napravljeno, ukratko

- JobSearchViewModel ima mapu hrvatskih i engleskih naziva županija

![image](https://github.com/user-attachments/assets/a8f3c95a-6058-4570-a133-2db70e2d6ad8)

- Kada se u tom novom elementu koji se zove Modal Bottom Sheet upiše nešto onda se filtrira popis županija hrvatskog imena i kada se odabere županija ona se spremi u _selectedCounty_
- kada se selectedCounty setta onda se popis poslova automatski filtrira prema toj županiji ali prema engleskom imenu jer geo API vraća engleski naziv županije
- I konačno ako korisnik želi pretraživati poslove preko search bara onda se to pretražuje na tom popisu poslova koji su filtrirani prema županiji

![image](https://github.com/user-attachments/assets/cca8a973-887e-4fcd-822a-d2ea7e2b3f82)

![image](https://github.com/user-attachments/assets/c7c9f1d1-8b41-4252-9b28-761a4a721359)

