### PR TITLE
Bauf 116 popraviti greske na franinim ekranima

### DIFF
--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -54,6 +54,7 @@ import hr.foi.air.baufind.ui.screens.UserProfileScreen.UserProfileViewModel
 import hr.foi.air.baufind.ui.screens.UserProfileScreen.userProfileScreen
 import hr.foi.air.baufind.ui.screens.WorkerSearchScreen.WorkerProfileScreen
 import hr.foi.air.baufind.ui.screens.WorkerSearchScreen.WorkerSearchScreen
+import hr.foi.air.baufind.ui.screens.WorkerSearchScreen.WorkerSearchViewModel
 import hr.foi.air.baufind.ui.theme.BaufindTheme
 import hr.foi.air.baufind.ws.network.AppTokenProvider
 import kotlinx.coroutines.coroutineScope
@@ -74,6 +75,7 @@ class MainActivity : ComponentActivity() {
         val myJobsViewModel = MyJobsViewModel()
         val jobNotificationViewModel = JobNotificationViewModel()
         val myJobNotificationViewModel = MyJobsNotificationsViewModel()
+        val workerSearchViewModel = WorkerSearchViewModel()
 
         requestNotificationPermissions()
 
@@ -163,7 +165,7 @@ class MainActivity : ComponentActivity() {
                                 val jobId = backStackEntry.arguments?.getInt("jobId")
 
                                 deserializedList = gson.fromJson(position, Array<Int>::class.java).toMutableList()
-                                WorkerSearchScreen(navController,tokenProvider,deserializedList, jobId!!)
+                                WorkerSearchScreen(navController,tokenProvider,deserializedList, jobId!!, workerSearchViewModel, jobViewModel)
                             }
                             composable(
                                 "workersProfileScreen/{jobId}/{workerId}/{skillId}",
@@ -183,9 +185,9 @@ class MainActivity : ComponentActivity() {
                                     context = this@MainActivity,
                                     tokenProvider = tokenProvider,
                                     id = workerId,
-                                    skills = deserializedList,
                                     jobId = jobId,
-                                    skillId = skillId
+                                    skillId = skillId,
+                                    workerSearchViewModel
                                 )
                             }
 

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/JobService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobService/JobService.kt
@@ -155,9 +155,6 @@ class JobService(){
 
     suspend fun confirmWorker(tokenProvider: TokenProvider, request: ConfirmWorkerRequest): ConfirmWorkerResponse {
         val service = NetworkService.createJobService(tokenProvider)
-
-
-        Log.d("Ovaj detch", request.toString())
         return try {
             service.confirmWorker(request)
         } catch (e: Exception) {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/MyJobNotificationListItem.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/MyJobNotificationListItem.kt
@@ -37,13 +37,8 @@ fun MyJobNotificationListItem(
     ){
         Column {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(text = "Id posla: ", modifier = Modifier.weight(0.3f))
-                Text(text = job.jobId.toString(), modifier = Modifier.weight(0.7f))
-
-            }
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(text = "Naziv posla: ", modifier = Modifier.weight(0.3f))
-                Text(text = job.jobTitle, modifier = Modifier.weight(0.7f))
+                Text(text = "Naziv posla: ", modifier = Modifier.weight(0.4f))
+                Text(text = job.jobTitle, modifier = Modifier.weight(0.6f))
             }
         }
     }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCardNotificationDetail.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/WorkerCardNotificationDetail.kt
@@ -78,8 +78,6 @@ fun WorkerCardNotificationDetail(
                     )
                 }
             }
-
-            // Gumbi sa weight-om za zauzimanje pola prostora
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 modifier = Modifier

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobNotificationDetailScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobNotificationDetailScreen.kt
@@ -126,7 +126,7 @@ fun MyJobNotificationDetailScreen(
 
                         item {
                             Text(
-                                text = "Skill : $skill",
+                                text = "Uloga : $skill",
                                 modifier = Modifier.padding(8.dp),
                                 fontSize = 18.sp,
                                 fontWeight = FontWeight.Bold

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobNotificationDetailScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobNotificationDetailScreen.kt
@@ -32,8 +32,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import hr.foi.air.baufind.ui.components.MyJobNotificationListItem
-import hr.foi.air.baufind.ui.components.WorkerCard
 import hr.foi.air.baufind.ui.components.WorkerCardNotificationDetail
 import hr.foi.air.baufind.ws.model.Worker
 import hr.foi.air.baufind.ws.network.TokenProvider

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerProfileScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerProfileScreen.kt
@@ -1,6 +1,7 @@
 package hr.foi.air.baufind.ui.screens.WorkerSearchScreen
 
 import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -19,7 +20,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Phone
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -41,7 +41,6 @@ import androidx.compose.ui.text.font.FontWeight.Companion.Bold
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import hr.foi.air.baufind.helpers.PictureHelper.Companion.decodeBase64ToByteArray
 import hr.foi.air.baufind.service.UserProfileService.UserProfileService
@@ -60,13 +59,12 @@ fun WorkerProfileScreen(
     context: Context,
     tokenProvider: TokenProvider,
     id: Int,
-    skills: MutableList<Int>,
     jobId : Int,
-    skillId : Int
+    skillId : Int,
+    viewModel: WorkerSearchViewModel
 )  {
     val coroutineScope = rememberCoroutineScope()
     val userProfileService = UserProfileService(tokenProvider)
-    val viewModel: WorkerSearchViewModel = viewModel()
     viewModel.tokenProvider.value = tokenProvider
     val userProfile = remember { mutableStateOf<UserProfileResponse?>(null) }
     val isLoading = remember { mutableStateOf(true) }
@@ -257,9 +255,13 @@ fun WorkerProfileScreen(
                                     )
 
                                     if (response.success) {
-                                        skills.remove(skills.first())
-                                        navController.navigate("workersSearchScreen/${skills}/${jobId}")
-                                    } else {
+                                        viewModel.skillsId.value.remove(skillId)
+                                        viewModel.skillsId.value = viewModel.skillsId.value
+                                        if (viewModel.skillsId.value.isEmpty()) viewModel.isEmptyList = true
+
+                                        navController.popBackStack()
+                                    }
+                                    else {
                                         Toast.makeText(context, response.message, Toast.LENGTH_LONG).show()
                                     }
                                 } catch (e: Exception) {

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerProfileScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/WorkerSearchScreen/WorkerProfileScreen.kt
@@ -15,7 +15,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.outlined.Email
@@ -66,6 +69,7 @@ fun WorkerProfileScreen(
     val coroutineScope = rememberCoroutineScope()
     val userProfileService = UserProfileService(tokenProvider)
     viewModel.tokenProvider.value = tokenProvider
+    val scrollState = rememberScrollState()
     val userProfile = remember { mutableStateOf<UserProfileResponse?>(null) }
     val isLoading = remember { mutableStateOf(true) }
 
@@ -83,8 +87,10 @@ fun WorkerProfileScreen(
             Column (
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+                    .padding(16.dp)
+                    .verticalScroll(scrollState),
+                horizontalAlignment = Alignment.CenterHorizontally,
+
             ) {
                 Box(
                     modifier = Modifier


### PR DESCRIPTION
Popravljeni sljedeći bugovi:
- Kad se treba pozvati radnika na posao, ne može se scrollati po ekranu, što može dovesti do situacije da se gumb za poziv na posao ne vidi.

- Kada se radnik odbije na poslu, njegovo mjesto ostane zauzeto i nitko se ne može prijaviti na njegovu poziciju.

- Na ekranu gdje se ranik poziva na posao kad se vrati nazad, otvara se novi ekran za pretraživanje radnika, umjesto da se vrati na stari. Ovo stvara problem jer korisnik se više puta izmjenjuje na ekranima za pretraživanje i pozivanje radnika kako bi se vratio natrag.

- Maknuti ID sa “kartice” posla kod notifikacija za prihvaćanje ili odbijanje zahtjeva posla od strane radnika. “MyJobNotificationDetails”.

- Promijeniti “Skill” u “Pozicija” ili “Uloga” ili nešto na ekranu MyJobNotificationDetails