### PR TITLE
Bauf 23 kao korisnik elim pregledati povijest poslova kako bih mogao vidjeti sve prija nje poslove

### DIFF
--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetAllJobsHistory/AllJobsHistoryRecord.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetAllJobsHistory/AllJobsHistoryRecord.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BusinessLogicLayer.AppLogic.Jobs.GetAllJobsHistory
+{
+    public record AllJobsHistoryRecord
+    {
+        public int JobId { get; set; }
+        public string Title { get; set; }
+        public byte[] Picture { get; set; }
+        public string CompletionDate { get; set; }
+        public bool IsOwner { get; set; }
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetAllJobsHistory/GetAllJobsHistoryResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetAllJobsHistory/GetAllJobsHistoryResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BusinessLogicLayer.AppLogic.Jobs.GetAllJobsHistory
+{
+    public record GetAllJobsHistoryResponse
+    {
+        public List<AllJobsHistoryRecord> Jobs { get; set; }
+        public string Error { get; set; }
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobHistory/GetJobHistoryResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobHistory/GetJobHistoryResponse.cs
@@ -8,7 +8,7 @@ namespace BusinessLogicLayer.AppLogic.Jobs.GetJobHistory
 {
     public record GetJobHistoryResponse
     {
-        public List<JobHistoryRecord> jobHistory { get; set; }
+        public JobHistoryRecord JobHistory { get; set; }
         public string? Error { get; set; }
     }
 }

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobHistory/GetJobHistoryResponse.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobHistory/GetJobHistoryResponse.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BusinessLogicLayer.AppLogic.Jobs.GetJobHistory
+{
+    public record GetJobHistoryResponse
+    {
+        public List<JobHistoryRecord> jobHistory { get; set; }
+        public string? Error { get; set; }
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobHistory/JobHistoryRecord.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobHistory/JobHistoryRecord.cs
@@ -1,0 +1,20 @@
+﻿using DataAccessLayer.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BusinessLogicLayer.AppLogic.Jobs.GetJobHistory
+{
+    public record JobHistoryRecord
+    {
+        public int JobId { get; set; }
+        public string JobTitle { get; set; }
+        public string JobDescription { get; set; }
+        public string JobLocation { get; set; }
+        public string JobOwnerName { get; set; }
+        public List<WorkerOnJobModel> Workers { get; set; }
+        public List<EventsModel> Events { get; set; }
+    }
+}

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobHistory/JobHistoryRecord.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/GetJobHistory/JobHistoryRecord.cs
@@ -9,12 +9,12 @@ namespace BusinessLogicLayer.AppLogic.Jobs.GetJobHistory
 {
     public record JobHistoryRecord
     {
-        public int JobId { get; set; }
-        public string JobTitle { get; set; }
-        public string JobDescription { get; set; }
-        public string JobLocation { get; set; }
-        public string JobOwnerName { get; set; }
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public string Location { get; set; }
+        public string OwnerName { get; set; }
         public List<WorkerOnJobModel> Workers { get; set; }
-        public List<EventsModel> Events { get; set; }
+        public List<EventModel> Events { get; set; }
     }
 }

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
@@ -1,6 +1,7 @@
 ﻿using BusinessLogicLayer.AppLogic.Jobs.AddJob;
 using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
 using BusinessLogicLayer.AppLogic.Jobs.ConfirmWorker;
+using BusinessLogicLayer.AppLogic.Jobs.GetAllJobsHistory;
 using BusinessLogicLayer.AppLogic.Jobs.GetJob;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 using BusinessLogicLayer.AppLogic.Jobs.WorkerJoinJob;
@@ -19,5 +20,6 @@ namespace BusinessLogicLayer.AppLogic.Jobs
         public WorkerRequestJoinResponse WorkerRequestJoin(WorkerRequestJoinRequest request, int userId);
         public ConfirmWorkerResponse ConfirmWorkerRequest(ConfirmWorkerRequest request);
         public MyJobsNotificationResponse GetMyJobsNotifications(int EmployerId);
+        public GetAllJobsHistoryResponse GetAllJobsHistory(int userId);
     }
 }

--- a/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
+++ b/Software/Backend/BusinessLogicLayer/AppLogic/Jobs/IJobService.cs
@@ -3,6 +3,7 @@ using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
 using BusinessLogicLayer.AppLogic.Jobs.ConfirmWorker;
 using BusinessLogicLayer.AppLogic.Jobs.GetAllJobsHistory;
 using BusinessLogicLayer.AppLogic.Jobs.GetJob;
+using BusinessLogicLayer.AppLogic.Jobs.GetJobHistory;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 using BusinessLogicLayer.AppLogic.Jobs.WorkerJoinJob;
 
@@ -21,5 +22,6 @@ namespace BusinessLogicLayer.AppLogic.Jobs
         public ConfirmWorkerResponse ConfirmWorkerRequest(ConfirmWorkerRequest request);
         public MyJobsNotificationResponse GetMyJobsNotifications(int EmployerId);
         public GetAllJobsHistoryResponse GetAllJobsHistory(int userId);
+        public GetJobHistoryResponse GetJobHistory(int jobId, int userId);
     }
 }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -348,7 +348,7 @@ namespace BusinessLogicLayer.Infrastructure
         public GetJobHistoryResponse GetJobHistory(int jobId, int userId)
             //TODO: validacija je li korisnik bio na tom poslu kao vlasnik ili radnik
         {
-            var jobData = _jobRepository.GetAllJobsHistory(int jobId);
+            var jobData = _jobRepository.GetJobHistory(jobId);
 
             if (jobData == null)
             {
@@ -358,10 +358,21 @@ namespace BusinessLogicLayer.Infrastructure
                 };
             }
 
-            //convertat podatke
-            //returnat podatke
+            var jobHistory = new JobHistoryRecord()
+            {
+                Id = jobData.JobId,
+                Title = jobData.JobTitle,
+                Description = jobData.JobDescription,
+                Location = jobData.JobLocation,
+                OwnerName = jobData.JobOwnerName,
+                Workers = jobData.Workers,
+                Events = jobData.Events
+            };
 
-            return null;
+            return new GetJobHistoryResponse()
+            {
+                JobHistory = jobHistory
+            };
         }
     }
 }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -6,6 +6,7 @@ using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
 using BusinessLogicLayer.AppLogic.Jobs.ConfirmWorker;
 using BusinessLogicLayer.AppLogic.Jobs.GetAllJobsHistory;
 using BusinessLogicLayer.AppLogic.Jobs.GetJob;
+using BusinessLogicLayer.AppLogic.Jobs.GetJobHistory;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 using BusinessLogicLayer.AppLogic.Jobs.WorkerJoinJob;
 using BusinessLogicLayer.AppLogic.PushNotifications;
@@ -344,5 +345,23 @@ namespace BusinessLogicLayer.Infrastructure
             }
         }
 
+        public GetJobHistoryResponse GetJobHistory(int jobId, int userId)
+            //TODO: validacija je li korisnik bio na tom poslu kao vlasnik ili radnik
+        {
+            var jobData = _jobRepository.GetAllJobsHistory(int jobId);
+
+            if (jobData == null)
+            {
+                return new GetJobHistoryResponse()
+                {
+                    Error = "Posao nije pronađen!"
+                };
+            }
+
+            //convertat podatke
+            //returnat podatke
+
+            return null;
+        }
     }
 }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -4,6 +4,7 @@ using BusinessLogicLayer.AppLogic.Jobs;
 using BusinessLogicLayer.AppLogic.Jobs.AddJob;
 using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
 using BusinessLogicLayer.AppLogic.Jobs.ConfirmWorker;
+using BusinessLogicLayer.AppLogic.Jobs.GetAllJobsHistory;
 using BusinessLogicLayer.AppLogic.Jobs.GetJob;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 using BusinessLogicLayer.AppLogic.Jobs.WorkerJoinJob;
@@ -312,6 +313,35 @@ namespace BusinessLogicLayer.Infrastructure
                 response.Message = $"Nešto je pošlo krivo: {ex.Message}";
             }
             return response;
+        }
+
+        public GetAllJobsHistoryResponse GetAllJobsHistory(int userId)
+        {
+            var jobList = _jobRepository.GetAllJobsHistory(userId);
+
+            if (jobList == null)
+            {
+                return new GetAllJobsHistoryResponse()
+                {
+                    Error = "Niste sudjelovali na nijednom poslu!"
+                };
+            }
+            else
+            {
+                var jobHistoryRecords = jobList.Select(job => new AllJobsHistoryRecord
+                {
+                    JobId = job.JobId,
+                    Title = job.Title,
+                    Picture = job.Picture,
+                    CompletionDate = job.CompletionDate,
+                    IsOwner = job.IsOwner
+                }).ToList();
+
+                return new GetAllJobsHistoryResponse()
+                {
+                    Jobs = jobHistoryRecords
+                };
+            }
         }
 
     }

--- a/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
+++ b/Software/Backend/BusinessLogicLayer/Infrastructure/JobService.cs
@@ -346,8 +346,15 @@ namespace BusinessLogicLayer.Infrastructure
         }
 
         public GetJobHistoryResponse GetJobHistory(int jobId, int userId)
-            //TODO: validacija je li korisnik bio na tom poslu kao vlasnik ili radnik
         {
+            bool isValid = _jobRepository.CheckIfUserWorkedOrOwnedJob(jobId, userId);
+            if (!isValid)
+            {
+                return new GetJobHistoryResponse()
+                {
+                    Error = "Niste sudjelovali na ovom poslu!"
+                };
+            }
             var jobData = _jobRepository.GetJobHistory(jobId);
 
             if (jobData == null)

--- a/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
+++ b/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
@@ -65,5 +65,7 @@ namespace DataAccessLayer.AppLogic
         /// <param name="userId"></param>
         /// <returns>Poslovi imaju: id, naslov, jednu sliku, datum završetka, bool je li vlasnik, </returns>
         public List<AllJobsHistoryModel> GetAllJobsHistory(int userId);
+
+        public JobHistoryModel GetJobHistory(int jobId);
     }
 }

--- a/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
+++ b/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
@@ -64,8 +64,21 @@ namespace DataAccessLayer.AppLogic
         /// </summary>
         /// <param name="userId"></param>
         /// <returns>Poslovi imaju: id, naslov, jednu sliku, datum završetka, bool je li vlasnik, </returns>
+        /// 
         public List<AllJobsHistoryModel> GetAllJobsHistory(int userId);
-
+        /// <summary>
+        /// Dohvaća podatke koji se prikazuju na history-u za jedan posao
+        /// </summary>
+        /// <param name="jobId"></param>
+        /// <returns>Vraća id, naziv, opis i lokaciju posla. Ime vlasnika posla, popis radnika i imena njihovih pozicija. Kronoloski slijed dogadaja posla.</returns>
         public JobHistoryModel GetJobHistory(int jobId);
+
+        /// <summary>
+        /// Provjerava je li korisnik radio na poslu ili bio vlasnik posla kako bi se znalo smije li gledati taj posao u povijesti
+        /// </summary>
+        /// <param name="jobId"></param>
+        /// <param name="userId"></param>
+        /// <returns>Boolean</returns>
+        bool CheckIfUserWorkedOrOwnedJob(int jobId, int userId);
     }
 }

--- a/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
+++ b/Software/Backend/DataAccessLayer/AppLogic/IJobRepository.cs
@@ -58,5 +58,12 @@ namespace DataAccessLayer.AppLogic
         /// <param name="userId"></param>
         /// <returns></returns>
         public List<MyJobModel> GetMyJobsForUser(int userId);
+
+        /// <summary>
+        /// Funkcija dobiva userId korisnika i vraća popis poslova koji su završili a na kojima je korisnik bio radnik ili vlasnik
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <returns>Poslovi imaju: id, naslov, jednu sliku, datum završetka, bool je li vlasnik, </returns>
+        public List<AllJobsHistoryModel> GetAllJobsHistory(int userId);
     }
 }

--- a/Software/Backend/DataAccessLayer/AppLogic/IWorkerRepository.cs
+++ b/Software/Backend/DataAccessLayer/AppLogic/IWorkerRepository.cs
@@ -8,5 +8,11 @@ using System.Threading.Tasks;
 namespace DataAccessLayer.AppLogic {
     public interface IWorkerRepository {
         public List<WorkerModel>? GetWorkers(string skill);
+        /// <summary>
+        /// Za posao dohvaća imena radnika i imena pozicija koje su imali na tom poslu
+        /// </summary>
+        /// <param name="jobId"></param>
+        /// <returns>Za posao dohvaća imena radnika i imena pozicija koje su imali na tom poslu</returns>
+        public List<WorkerOnJobModel> GetWorkerNameAndSkillTitleForJob(int jobId);
     }
 }

--- a/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
@@ -333,12 +333,12 @@ namespace DataAccessLayer.Infrastructure
         {
             string query = @"
                 SELECT j.id, j.title, jh.datetime, 
-                        CASE WHEN j.employer_id = @userId THEN 1 ELSE 0 END AS is_owner
+                       CASE WHEN j.employer_id = @userId THEN 1 ELSE 0 END AS is_owner
                 FROM job j
                 JOIN job_history jh ON j.id = jh.job_id
                 WHERE (j.employer_id = @userId OR j.id IN (
                     SELECT w.job_id FROM working w
-                    WHERE w.worker_id = @userId
+                    WHERE w.worker_id = @userId AND w.working_status_id = 4
                 ))
                 AND j.job_status_id = 3
                 AND jh.job_status_id = 3;

--- a/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/JobRepository.cs
@@ -470,5 +470,32 @@ namespace DataAccessLayer.Infrastructure
             }
             return events;
         }
+        /// <summary>
+        /// Provjerava je li korisnik radio na poslu ili bio vlasnik posla kako bi se znalo smije li gledati taj posao u povijesti
+        /// </summary>
+        /// <param name="jobId"></param>
+        /// <param name="userId"></param>
+        /// <returns>Boolean</returns>
+        public bool CheckIfUserWorkedOrOwnedJob(int jobId, int userId)
+        {
+            string query = @"
+                SELECT 1
+                FROM job j
+                WHERE j.id = @jobId
+                AND (j.employer_id = @userId OR j.id IN (
+                    SELECT w.job_id FROM working w
+                    WHERE w.worker_id = @userId AND w.working_status_id = 4
+                ));
+            ";
+            var parameters = new Dictionary<string, object>
+            {
+                { "@jobId", jobId },
+                { "@userId", userId }
+            };
+            using(var reader = _db.ExecuteReader(query, parameters))
+            {
+                return reader.Read();
+            }
+        }
     }
 }

--- a/Software/Backend/DataAccessLayer/Infrastructure/WorkerRepository.cs
+++ b/Software/Backend/DataAccessLayer/Infrastructure/WorkerRepository.cs
@@ -83,6 +83,42 @@ GROUP BY
 
             };
         }
+        /// <summary>
+        /// Za posao dohvaća imena radnika i imena pozicija koje su imali na tom poslu
+        /// </summary>
+        /// <param name="jobId"></param>
+        /// <returns>Za posao dohvaća imena radnika i imena pozicija koje su imali na tom poslu</returns>
+        public List<WorkerOnJobModel> GetWorkerNameAndSkillTitleForJob(int jobId)
+        {
+            string query = @"
+                SELECT u.name AS WorkerName, s.title AS RoleTitle
+                FROM working w
+                JOIN app_user u ON w.worker_id = u.id
+                JOIN skill s ON w.skill_id = s.id
+                WHERE w.job_id = @jobId
+                AND w.working_status_id = 4;
+            ";
+
+            var parameters = new Dictionary<string, object>
+            {
+                { "@jobId", jobId }
+            };
+
+            var workers = new List<WorkerOnJobModel>();
+
+            using (var reader = dB.ExecuteReader(query, parameters))
+            {
+                while (reader.Read())
+                {
+                    workers.Add(new WorkerOnJobModel
+                    {
+                        WorkerName = (string)reader["WorkerName"],
+                        RoleTitle = (string)reader["RoleTitle"]
+                    });
+                }
+            }
+            return workers;
+        }
 
     }
 }

--- a/Software/Backend/DataAccessLayer/Models/AllJobsHistoryModel.cs
+++ b/Software/Backend/DataAccessLayer/Models/AllJobsHistoryModel.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccessLayer.Models
+{
+    public record AllJobsHistoryModel
+    {
+        public int JobId { get; set; }
+        public string Title { get; set; }
+        public byte[] Picture { get; set; }
+        public string CompletionDate { get; set; }
+        public bool IsOwner { get; set; }
+    }
+}

--- a/Software/Backend/DataAccessLayer/Models/EventModel.cs
+++ b/Software/Backend/DataAccessLayer/Models/EventModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccessLayer.Models
+{
+    public record EventModel
+    {
+        public string EventName { get; set; }
+        public string Date { get; set; }
+    }
+}

--- a/Software/Backend/DataAccessLayer/Models/JobHistoryModel.cs
+++ b/Software/Backend/DataAccessLayer/Models/JobHistoryModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccessLayer.Models
+{
+    public record JobHistoryModel
+    {
+        public int JobId { get; set; }
+        public string JobTitle { get; set; }
+        public string JobDescription { get; set; }
+        public string JobLocation { get; set; }
+        public string JobOwnerName { get; set; }
+        public List<WorkerOnJobModel> Workers { get; set; }
+        public List<EventModel> Events { get; set; }
+    }
+}

--- a/Software/Backend/DataAccessLayer/Models/WorkerOnJobModel.cs
+++ b/Software/Backend/DataAccessLayer/Models/WorkerOnJobModel.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DataAccessLayer.Models
+{
+    public record WorkerOnJobModel
+    {
+        public string WorkerName { get; set; }
+        public string RoleTitle { get; set; }
+    }
+}

--- a/Software/Backend/WebApi/Controllers/JobController.cs
+++ b/Software/Backend/WebApi/Controllers/JobController.cs
@@ -5,6 +5,7 @@ using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
 using BusinessLogicLayer.AppLogic.Jobs.ConfirmWorker;
 using BusinessLogicLayer.AppLogic.Jobs.GetAllJobsHistory;
 using BusinessLogicLayer.AppLogic.Jobs.GetJob;
+using BusinessLogicLayer.AppLogic.Jobs.GetJobHistory;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 using BusinessLogicLayer.AppLogic.Jobs.WorkerJoinJob;
 using Microsoft.AspNetCore.Authorization;
@@ -242,9 +243,21 @@ public class JobController : ControllerBase
         }
     }
 
-    /*
-     * [HttpGet("history/{id}")]
-     * [Authorize]
-     * public ActionResult<GetJobHistoryReponse> GetJobHistory()
-     */
+    [HttpGet("history/{id}")]
+    [Authorize]
+    public ActionResult<GetJobHistoryResponse> GetJobHistory(int id)
+    {
+        var userIdFromJwt = HttpContext.Items["UserId"] as int?;
+        if (userIdFromJwt == null)
+        {
+            return Unauthorized(new GetJobHistoryResponse()
+            {
+                Error = "Ne možete pristupiti tom resursu!"
+            });
+        }
+        else
+        {
+            return _jobService.GetJobHistory(id, userIdFromJwt.Value);
+        }
+    }
 }

--- a/Software/Backend/WebApi/Controllers/JobController.cs
+++ b/Software/Backend/WebApi/Controllers/JobController.cs
@@ -3,6 +3,7 @@ using BusinessLogicLayer.AppLogic.Jobs;
 using BusinessLogicLayer.AppLogic.Jobs.AddJob;
 using BusinessLogicLayer.AppLogic.Jobs.AddUserToJob;
 using BusinessLogicLayer.AppLogic.Jobs.ConfirmWorker;
+using BusinessLogicLayer.AppLogic.Jobs.GetAllJobsHistory;
 using BusinessLogicLayer.AppLogic.Jobs.GetJob;
 using BusinessLogicLayer.AppLogic.Jobs.GetJobsForCurrentUser;
 using BusinessLogicLayer.AppLogic.Jobs.WorkerJoinJob;
@@ -63,7 +64,7 @@ public class JobController : ControllerBase
         }
 
         var jobs = _jobService.GetJobsForCurrentUser(userIdFromJwt.Value);
-        
+
         return jobs;
     }
 
@@ -89,7 +90,7 @@ public class JobController : ControllerBase
         return job;
 
     }
-    
+
     [HttpPut("CallForWorking")]
     [Authorize]
     public ActionResult<CallWarkerToJobResponse> CallWorkerToJob([FromBody] CallWorkerToJobRequest request)
@@ -219,8 +220,31 @@ public class JobController : ControllerBase
         }
         else
         {
-            return  _jobService.GetMyJobsNotifications((int)userIdFromJwt);
+            return _jobService.GetMyJobsNotifications((int)userIdFromJwt);
         }
     }
 
+    [HttpGet("getHistory")]
+    [Authorize]
+    public ActionResult<GetAllJobsHistoryResponse> GetAllJobsHistory()
+    {
+        var userIdFromJwt = HttpContext.Items["UserId"] as int?;
+        if (userIdFromJwt == null)
+        {
+            return Unauthorized(new GetAllJobsHistoryResponse()
+            {
+                Error = "Ne možete pristupiti tom resursu!"
+            });
+        }
+        else
+        {
+            return _jobService.GetAllJobsHistory(userIdFromJwt.Value);
+        }
+    }
+
+    /*
+     * [HttpGet("history/{id}")]
+     * [Authorize]
+     * public ActionResult<GetJobHistoryReponse> GetJobHistory()
+     */
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -118,7 +118,9 @@ class MainActivity : ComponentActivity() {
                                 "jobSearchDetailsScreen",
                                 "settingsScreen",
                                 "pendingJobsScreen",
-                                "myJobsScreen"
+                                "myJobsScreen",
+                                "wholeHistoryScreen",
+                                "selectedJobHistoryScreen"
                             )
                         ) {
                             BottomNavigationBar(navController = navController)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -35,6 +35,9 @@ import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobAddSkillsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobPositionsLocationScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobViewModel
+import hr.foi.air.baufind.ui.screens.JobHistoryScreen.SelectedJobHistoryViewModel
+import hr.foi.air.baufind.ui.screens.JobHistoryScreen.WholeHistoryScreen
+import hr.foi.air.baufind.ui.screens.JobHistoryScreen.WholeHistoryViewModel
 import hr.foi.air.baufind.ui.screens.JobRoom.JobRoomScreen
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchDetailsScreen
 import hr.foi.air.baufind.ui.screens.JobSearchScreen.JobSearchDetailsViewModel
@@ -81,6 +84,8 @@ class MainActivity : ComponentActivity() {
         val myJobNotificationViewModel = MyJobsNotificationsViewModel()
         val workerSearchViewModel = WorkerSearchViewModel()
         val reviewNotificationsViewModel = ReviewNotificationViewModel()
+        val wholeHistoryViewModel = WholeHistoryViewModel()
+        val selectedJobHistoryViewModel = SelectedJobHistoryViewModel()
 
 
         requestNotificationPermissions()
@@ -279,7 +284,7 @@ class MainActivity : ComponentActivity() {
                                 )
                             }
 
-
+                            composable("wholeHistoryScreen") { WholeHistoryScreen(navController, tokenProvider, wholeHistoryViewModel, selectedJobHistoryViewModel) }
                         }
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/MainActivity.kt
@@ -35,6 +35,7 @@ import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobAddSkillsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobDetailsScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobPositionsLocationScreen
 import hr.foi.air.baufind.ui.screens.JobCreateScreen.JobViewModel
+import hr.foi.air.baufind.ui.screens.JobHistoryScreen.SelectedJobHistoryScreen
 import hr.foi.air.baufind.ui.screens.JobHistoryScreen.SelectedJobHistoryViewModel
 import hr.foi.air.baufind.ui.screens.JobHistoryScreen.WholeHistoryScreen
 import hr.foi.air.baufind.ui.screens.JobHistoryScreen.WholeHistoryViewModel
@@ -285,6 +286,7 @@ class MainActivity : ComponentActivity() {
                             }
 
                             composable("wholeHistoryScreen") { WholeHistoryScreen(navController, tokenProvider, wholeHistoryViewModel, selectedJobHistoryViewModel) }
+                            composable("selectedJobHistoryScreen") { SelectedJobHistoryScreen(navController, tokenProvider, selectedJobHistoryViewModel) }
                         }
                     }
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/FullJobHistoryResponse.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/FullJobHistoryResponse.kt
@@ -1,0 +1,9 @@
+package hr.foi.air.baufind.service.JobHistoryService
+
+import hr.foi.air.baufind.ws.model.AllJobsHistoryModel
+
+data class FullJobHistoryResponse(
+    val success: Boolean,
+    val message: String?,
+    val jobs: List<AllJobsHistoryModel>
+)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/JobHistoryResponse.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/JobHistoryResponse.kt
@@ -1,0 +1,9 @@
+package hr.foi.air.baufind.service.JobHistoryService
+
+import hr.foi.air.baufind.ws.model.JobHistoryModel
+
+data class JobHistoryResponse(
+    val success: Boolean,
+    val message: String?,
+    val jobHistory: JobHistoryModel?
+)

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/JobHistoryService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/JobHistoryService.kt
@@ -35,12 +35,12 @@ class JobHistoryService {
         }
     }
 
-    suspend fun fetchJobHistoryAsync(tokenProvider: TokenProvider): JobHistoryResponse {
+    suspend fun fetchJobHistoryAsync(tokenProvider: TokenProvider, jobId: Int): JobHistoryResponse {
         val service = NetworkService.createJobService(tokenProvider)
         try{
-            val response = service.getJobHistory()
+            val response = service.getJobHistory(jobId)
             Log.d("Povijest odabranog posla je", response.toString())
-            if(response.error == ""){
+            if(response.error == null){
                 return JobHistoryResponse(
                     true,
                     "",

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/JobHistoryService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/JobHistoryService.kt
@@ -1,0 +1,65 @@
+package hr.foi.air.baufind.service.JobHistoryService
+
+import android.util.Log
+import hr.foi.air.baufind.ws.network.NetworkService
+import hr.foi.air.baufind.ws.network.TokenProvider
+
+class JobHistoryService {
+    suspend fun fetchFullJobHistoryAsync(tokenProvider: TokenProvider): FullJobHistoryResponse {
+        val service = NetworkService.createJobService(tokenProvider)
+        try{
+            val response = service.getFullJobHistory()
+            Log.d("Puna povijest poslova je", response.toString())
+            if(response.error == ""){
+                return FullJobHistoryResponse(
+                    true,
+                    "",
+                    response.jobs
+                )
+            }else{
+                return FullJobHistoryResponse(
+                    false,
+                    response.error,
+                    listOf()
+                )
+            }
+        }catch(e: Exception){
+            e.printStackTrace()
+            Log.d("Puna povijest poslova ERROR", "Error: ${e.message}")
+            return FullJobHistoryResponse(
+                false,
+                "Pogreska pri fetchanju",
+                listOf()
+            )
+        }
+    }
+
+    suspend fun fetchJobHistoryAsync(tokenProvider: TokenProvider): JobHistoryResponse {
+        val service = NetworkService.createJobService(tokenProvider)
+        try{
+            val response = service.getJobHistory()
+            Log.d("Povijest odabranog posla je", response.toString())
+            if(response.error == ""){
+                return JobHistoryResponse(
+                    true,
+                    "",
+                    response.jobHistory
+                )
+            }else{
+                return JobHistoryResponse(
+                    false,
+                    response.error,
+                    null
+                )
+            }
+        }catch(e: Exception){
+            e.printStackTrace()
+            Log.d("Povijest odabranog posla ERROR", "Error: ${e.message}")
+            return JobHistoryResponse(
+                false,
+                "Pogreska pri fetchanju",
+                null
+            )
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/JobHistoryService.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/service/JobHistoryService/JobHistoryService.kt
@@ -10,7 +10,8 @@ class JobHistoryService {
         try{
             val response = service.getFullJobHistory()
             Log.d("Puna povijest poslova je", response.toString())
-            if(response.error == ""){
+            Log.d("Service svih poslova error:", response.error.toString())
+            if(response.error == null){
                 return FullJobHistoryResponse(
                     true,
                     "",

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/HistoryListJobItem.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/HistoryListJobItem.kt
@@ -1,0 +1,79 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import hr.foi.air.baufind.R
+import hr.foi.air.baufind.helpers.PictureHelper
+
+@Composable
+fun HistoryListJobItem(
+    picture: String,
+    name: String,
+    date: String,
+    onItemClick: () -> Unit
+){
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color.LightGray)
+            .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
+            .padding(8.dp)
+            .clickable { onItemClick() },
+        //horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ){
+        val imageData = PictureHelper.decodeBase64ToByteArray(picture)
+        val bitmap = imageData?.let { android.graphics.BitmapFactory.decodeByteArray(it, 0, it.size) }
+        if(bitmap != null){
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = "Slika posla",
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .padding(end = 16.dp)
+            )
+        }else{
+            Image(
+                painter = painterResource(id = R.drawable.image_icon),
+                contentDescription = "Nema slike",
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .padding(end = 16.dp)
+            )
+        }
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ){
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Naslov:", modifier = Modifier.weight(0.4f))
+                Text(text = name, modifier = Modifier.weight(0.6f))
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(text = "Datum završetka:", modifier = Modifier.weight(0.4f))
+                Text(text = date, modifier = Modifier.weight(0.6f))
+            }
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/JobEventItem.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/components/JobEventItem.kt
@@ -1,0 +1,40 @@
+package hr.foi.air.baufind.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun JobEventItem(
+    eventName: String,
+    eventDate: String
+){
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start
+    ) {
+        Spacer(
+            Modifier
+                .size(8.dp)
+                .clip(CircleShape)
+                .background(Color.Gray)
+        )
+        Spacer(Modifier.width(8.dp))
+        Column {
+            Text(text = eventName)
+            Text(text = eventDate)
+        }
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/SelectedJobHistoryScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/SelectedJobHistoryScreen.kt
@@ -1,4 +1,118 @@
 package hr.foi.air.baufind.ui.screens.JobHistoryScreen
 
-class SelectedJobHistoryScreen {
+import android.util.Log
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import hr.foi.air.baufind.ui.components.DisplayTextField
+import hr.foi.air.baufind.ui.components.JobEventItem
+import hr.foi.air.baufind.ui.components.PersonInRoomCard
+import hr.foi.air.baufind.ws.network.TokenProvider
+
+@Composable
+fun SelectedJobHistoryScreen(
+    navController: NavController,
+    tokenProvider: TokenProvider,
+    selectedJobHistoryViewModel: SelectedJobHistoryViewModel
+){
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+
+    LaunchedEffect(currentBackStackEntry){
+        selectedJobHistoryViewModel.clearData()
+        selectedJobHistoryViewModel.tokenProvider = tokenProvider
+
+    }
+
+    val scrollState = rememberScrollState()
+
+    if(selectedJobHistoryViewModel.isLoading()){
+        Text(text = "Učitavam...")
+    }
+    else if(selectedJobHistoryViewModel.hasError()){
+        Text(text = selectedJobHistoryViewModel.message!!)
+    }
+    else{
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(22.dp)
+                .verticalScroll(scrollState),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ){
+            Text(
+                text = selectedJobHistoryViewModel.job.value!!.title,
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                fontSize = 26.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = "Informacije o poslu",
+                modifier = Modifier.align(Alignment.Start),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            DisplayTextField(
+                title = "Opis",
+                text = selectedJobHistoryViewModel.job.value!!.description,
+                modifier = Modifier.fillMaxWidth()
+            )
+            DisplayTextField(
+                title = "Lokacija",
+                text = selectedJobHistoryViewModel.job.value!!.location,
+                modifier = Modifier.fillMaxWidth()
+            )
+            DisplayTextField(
+                title = "Vlasnik posla",
+                text = selectedJobHistoryViewModel.job.value!!.ownerName,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = "Radnici na poslu",
+                modifier = Modifier.align(Alignment.Start),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            selectedJobHistoryViewModel.job.value!!.workers.forEach { worker ->
+                PersonInRoomCard(workerName = worker.roleTitle + " - " + worker.workerName, onItemClick = {})
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = "Slijed događaja na poslu",
+                modifier = Modifier.align(Alignment.Start),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Column(
+                modifier = Modifier.align(Alignment.Start),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ){
+                selectedJobHistoryViewModel.job.value!!.events.forEach { event ->
+                    JobEventItem(
+                        eventName = event.eventName,
+                        eventDate = event.date
+                    )
+                }
+            }
+        }
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/SelectedJobHistoryScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/SelectedJobHistoryScreen.kt
@@ -1,0 +1,4 @@
+package hr.foi.air.baufind.ui.screens.JobHistoryScreen
+
+class SelectedJobHistoryScreen {
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/SelectedJobHistoryViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/SelectedJobHistoryViewModel.kt
@@ -1,0 +1,48 @@
+package hr.foi.air.baufind.ui.screens.JobHistoryScreen
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import hr.foi.air.baufind.service.JobHistoryService.JobHistoryResponse
+import hr.foi.air.baufind.service.JobHistoryService.JobHistoryService
+import hr.foi.air.baufind.ws.model.JobHistoryModel
+import hr.foi.air.baufind.ws.network.TokenProvider
+import kotlinx.coroutines.launch
+
+class SelectedJobHistoryViewModel : ViewModel() {
+    var success: Boolean = false
+    var message: String? = null
+    val job = mutableStateOf<JobHistoryModel?>(null)
+    var selectedJobId = mutableStateOf<Int?>(null)
+
+    var tokenProvider: TokenProvider? = null
+        set(value) {
+            field = value
+            value?.let { loadJobHistory(it) }
+        }
+
+    private fun loadJobHistory(tokenProvider: TokenProvider) {
+        viewModelScope.launch {
+            val service = JobHistoryService()
+            val response: JobHistoryResponse = service.fetchJobHistoryAsync(tokenProvider)
+            success = response.success
+            message = response.message
+            job.value = response.jobHistory
+        }
+    }
+
+    fun clearData(){
+        success = false
+        message = null
+        job.value = null
+        selectedJobId = mutableStateOf<Int?>(null)
+    }
+
+    fun isLoading() : Boolean{
+        return job.value == null && message == null
+    }
+
+    fun hasError() : Boolean{
+        return job.value == null && message != null
+    }
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/SelectedJobHistoryViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/SelectedJobHistoryViewModel.kt
@@ -1,5 +1,6 @@
 package hr.foi.air.baufind.ui.screens.JobHistoryScreen
 
+import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -24,7 +25,8 @@ class SelectedJobHistoryViewModel : ViewModel() {
     private fun loadJobHistory(tokenProvider: TokenProvider) {
         viewModelScope.launch {
             val service = JobHistoryService()
-            val response: JobHistoryResponse = service.fetchJobHistoryAsync(tokenProvider)
+            val response: JobHistoryResponse = service.fetchJobHistoryAsync(tokenProvider, selectedJobId.value!!)
+            Log.d("Povijest odabranog posla je", response.toString())
             success = response.success
             message = response.message
             job.value = response.jobHistory
@@ -35,7 +37,6 @@ class SelectedJobHistoryViewModel : ViewModel() {
         success = false
         message = null
         job.value = null
-        selectedJobId = mutableStateOf<Int?>(null)
     }
 
     fun isLoading() : Boolean{

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryScreen.kt
@@ -1,0 +1,4 @@
+package hr.foi.air.baufind.ui.screens.JobHistoryScreen
+
+class WholeHistoryScreen {
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryScreen.kt
@@ -1,6 +1,7 @@
 package hr.foi.air.baufind.ui.screens.JobHistoryScreen
 
 import android.util.Log
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -45,79 +47,78 @@ fun WholeHistoryScreen(
         wholeHistoryViewModel.tokenProvider = tokenProvider
     }
 
-    if(wholeHistoryViewModel.isLoading()){
-        Text(text = "Učitavam...")
-    }else if(wholeHistoryViewModel.hasError()){
-        Text(text = wholeHistoryViewModel.message!!)
-    }else{
-        val ownerJobs = wholeHistoryViewModel.jobs.value.filter { it.isOwner }
-        val workerJobs = wholeHistoryViewModel.jobs.value.filter { !it.isOwner }
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(22.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ){
-            Text(
-                text ="Moja povijest",
-                modifier = Modifier.align(Alignment.CenterHorizontally),
-                fontSize = 26.sp,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                text = "Poslovi na kojima sam bio vlasnik",
+    Scaffold(
+        modifier = Modifier.background(color = MaterialTheme.colorScheme.background),
+        content = { paddingValues ->
+            Column(
                 modifier = Modifier
-                    .align(Alignment.Start)
-                    .padding(bottom = 8.dp),
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Bold
-            )
-            LazyColumn(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                    .padding(paddingValues)
+                    .fillMaxWidth()
             ) {
-                items(ownerJobs) { job ->
-                    HistoryListJobItem(
-                        picture = job.picture,
-                        name = job.title,
-                        date = job.completionDate,
-                        onItemClick = {
-                            selectedJobHistoryViewModel.selectedJobId.value = job.jobId
-                            navController.navigate("selectedJobHistoryScreen")
+                if (wholeHistoryViewModel.isLoading()) {
+                    Text(text = "Učitavam...", modifier = Modifier.padding(16.dp))
+                } else if (wholeHistoryViewModel.hasError()) {
+                    Text(text = wholeHistoryViewModel.message ?: "Došlo je do pogreške", modifier = Modifier.padding(16.dp))
+                } else {
+                    val ownerJobs = wholeHistoryViewModel.jobs.value.filter { it.isOwner }
+                    val workerJobs = wholeHistoryViewModel.jobs.value.filter { !it.isOwner }
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(22.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (ownerJobs.isNotEmpty()) {
+                            item {
+                                Text(
+                                    text = "Poslovi na kojima sam bio vlasnik",
+                                    modifier = Modifier
+                                        .align(Alignment.Start)
+                                        .padding(bottom = 8.dp),
+                                    fontSize = 20.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                            items(ownerJobs) { job ->
+                                HistoryListJobItem(
+                                    picture = job.picture,
+                                    name = job.title,
+                                    date = job.completionDate,
+                                    onItemClick = {
+                                        selectedJobHistoryViewModel.selectedJobId.value = job.jobId
+                                        navController.navigate("selectedJobHistoryScreen")
+                                    }
+                                )
+                            }
                         }
-                    )
-                }
-            }
-            Spacer(modifier = Modifier.height(24.dp))
 
-            Text(
-                text = "Poslovi na kojima sam bio radnik",
-                modifier = Modifier
-                    .align(Alignment.Start)
-                    .padding(bottom = 8.dp),
-                fontSize = 20.sp,
-                fontWeight = FontWeight.Bold
-            )
-            LazyColumn(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(workerJobs) { job ->
-                    HistoryListJobItem(
-                        picture = job.picture,
-                        name = job.title,
-                        date = job.completionDate,
-                        onItemClick = {
-                            selectedJobHistoryViewModel.selectedJobId.value = job.jobId
-                            navController.navigate("selectedJobHistoryScreen")
+                        if (workerJobs.isNotEmpty()) {
+                            item {
+                                Text(
+                                    text = "Poslovi na kojima sam bio radnik",
+                                    modifier = Modifier
+                                        .align(Alignment.Start)
+                                        .padding(top = 16.dp, bottom = 8.dp),
+                                    fontSize = 20.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                            items(workerJobs) { job ->
+                                HistoryListJobItem(
+                                    picture = job.picture,
+                                    name = job.title,
+                                    date = job.completionDate,
+                                    onItemClick = {
+                                        selectedJobHistoryViewModel.selectedJobId.value = job.jobId
+                                        navController.navigate("selectedJobHistoryScreen")
+                                    }
+                                )
+                            }
                         }
-                    )
+                    }
                 }
             }
         }
-
-    }
+    )
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryScreen.kt
@@ -1,5 +1,6 @@
 package hr.foi.air.baufind.ui.screens.JobHistoryScreen
 
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -85,7 +86,7 @@ fun WholeHistoryScreen(
                         date = job.completionDate,
                         onItemClick = {
                             selectedJobHistoryViewModel.selectedJobId.value = job.jobId
-                            //prebacit na ekran
+                            navController.navigate("selectedJobHistoryScreen")
                         }
                     )
                 }
@@ -111,7 +112,7 @@ fun WholeHistoryScreen(
                         date = job.completionDate,
                         onItemClick = {
                             selectedJobHistoryViewModel.selectedJobId.value = job.jobId
-                            //prebacit na ekran
+                            navController.navigate("selectedJobHistoryScreen")
                         }
                     )
                 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryScreen.kt
@@ -1,4 +1,122 @@
 package hr.foi.air.baufind.ui.screens.JobHistoryScreen
 
-class WholeHistoryScreen {
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import hr.foi.air.baufind.ui.components.HistoryListJobItem
+import hr.foi.air.baufind.ws.network.TokenProvider
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WholeHistoryScreen(
+    navController: NavController,
+    tokenProvider: TokenProvider,
+    wholeHistoryViewModel: WholeHistoryViewModel,
+    selectedJobHistoryViewModel: SelectedJobHistoryViewModel
+) {
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+
+    LaunchedEffect(currentBackStackEntry){
+        wholeHistoryViewModel.clearData()
+        wholeHistoryViewModel.tokenProvider = tokenProvider
+    }
+
+    if(wholeHistoryViewModel.isLoading()){
+        Text(text = "Učitavam...")
+    }else if(wholeHistoryViewModel.hasError()){
+        Text(text = wholeHistoryViewModel.message!!)
+    }else{
+        val ownerJobs = wholeHistoryViewModel.jobs.value.filter { it.isOwner }
+        val workerJobs = wholeHistoryViewModel.jobs.value.filter { !it.isOwner }
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(22.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ){
+            Text(
+                text ="Moja povijest",
+                modifier = Modifier.align(Alignment.CenterHorizontally),
+                fontSize = 26.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Poslovi na kojima sam bio vlasnik",
+                modifier = Modifier
+                    .align(Alignment.Start)
+                    .padding(bottom = 8.dp),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(ownerJobs) { job ->
+                    HistoryListJobItem(
+                        picture = job.picture,
+                        name = job.title,
+                        date = job.completionDate,
+                        onItemClick = {
+                            selectedJobHistoryViewModel.selectedJobId.value = job.jobId
+                            //prebacit na ekran
+                        }
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
+                text = "Poslovi na kojima sam bio radnik",
+                modifier = Modifier
+                    .align(Alignment.Start)
+                    .padding(bottom = 8.dp),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            LazyColumn(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(workerJobs) { job ->
+                    HistoryListJobItem(
+                        picture = job.picture,
+                        name = job.title,
+                        date = job.completionDate,
+                        onItemClick = {
+                            selectedJobHistoryViewModel.selectedJobId.value = job.jobId
+                            //prebacit na ekran
+                        }
+                    )
+                }
+            }
+        }
+
+    }
 }

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryViewModel.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/JobHistoryScreen/WholeHistoryViewModel.kt
@@ -1,0 +1,49 @@
+package hr.foi.air.baufind.ui.screens.JobHistoryScreen
+
+import android.util.Log
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import hr.foi.air.baufind.service.JobHistoryService.FullJobHistoryResponse
+import hr.foi.air.baufind.service.JobHistoryService.JobHistoryService
+import hr.foi.air.baufind.ws.model.AllJobsHistoryModel
+import hr.foi.air.baufind.ws.network.TokenProvider
+import kotlinx.coroutines.launch
+
+class WholeHistoryViewModel : ViewModel() {
+    var success : Boolean = false
+    var message : String? = null
+    val jobs = mutableStateOf(emptyList<AllJobsHistoryModel>())
+
+    var tokenProvider: TokenProvider? = null
+    set(value){
+        field = value
+        value?.let { loadHistory(it) }
+    }
+
+    private fun loadHistory(tokenProvider: TokenProvider){
+        viewModelScope.launch {
+            val service = JobHistoryService()
+            val response : FullJobHistoryResponse = service.fetchFullJobHistoryAsync(tokenProvider)
+            Log.d("loadHistory je dobio", response.toString())
+            success = response.success
+            message = response.message
+            jobs.value = response.jobs
+        }
+    }
+
+    fun clearData(){
+        success = false
+        message = null
+        jobs.value = emptyList()
+    }
+
+    fun isLoading() : Boolean{
+        return jobs.value.isEmpty() && message == null
+    }
+
+    fun hasError() : Boolean{
+        return jobs.value.isEmpty() && message != null
+    }
+
+}

--- a/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
+++ b/Software/Frontend/app/src/main/java/hr/foi/air/baufind/ui/screens/MyJobsScreen/MyJobsScreen.kt
@@ -79,7 +79,9 @@ fun MyJobsScreen(
                     }
                 },
                 actions = {
-                    IconButton(onClick = { }) { // TODO: odvede na zaslon
+                    IconButton(onClick = {
+                        navController.navigate("wholeHistoryScreen")
+                    }) {
                         Icon(
                             painter = painterResource(R.drawable.baseline_history_24),
                             contentDescription = "History",

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/AllJobsHistoryModel.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/AllJobsHistoryModel.kt
@@ -3,7 +3,7 @@ package hr.foi.air.baufind.ws.model
 data class AllJobsHistoryModel(
     val jobId: Int,
     val title: String,
-    val picture: ByteArray,
+    val picture: String,
     val completionDate: String,
     val isOwner: Boolean
 )

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/AllJobsHistoryModel.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/AllJobsHistoryModel.kt
@@ -1,0 +1,9 @@
+package hr.foi.air.baufind.ws.model
+
+data class AllJobsHistoryModel(
+    val jobId: Int,
+    val title: String,
+    val picture: ByteArray,
+    val completionDate: String,
+    val isOwner: Boolean
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/EventModel.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/EventModel.kt
@@ -1,0 +1,6 @@
+package hr.foi.air.baufind.ws.model
+
+data class EventModel(
+    val eventName: String,
+    val date: String
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/JobHistoryModel.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/JobHistoryModel.kt
@@ -1,0 +1,11 @@
+package hr.foi.air.baufind.ws.model
+
+data class JobHistoryModel(
+    val id: Int,
+    val title: String,
+    val description: String,
+    val location: String,
+    val ownerName: String,
+    val workers: List<WorkerOnJobModel>,
+    val events: List<EventModel>
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/WorkerOnJobModel.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/model/WorkerOnJobModel.kt
@@ -1,0 +1,6 @@
+package hr.foi.air.baufind.ws.model
+
+data class WorkerOnJobModel(
+    val workerName: String,
+    val roleTitle: String
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
@@ -7,6 +7,8 @@ import hr.foi.air.baufind.ws.request.WorkerRequestJoinBody
 import hr.foi.air.baufind.ws.response.CallForWorkingResponse
 import hr.foi.air.baufind.ws.response.CheckJobNotificationResponse
 import hr.foi.air.baufind.ws.response.ConfirmWorkerResponse
+import hr.foi.air.baufind.ws.response.GetFullJobHistoryResponse
+import hr.foi.air.baufind.ws.response.GetJobHistoryResponse
 import hr.foi.air.baufind.ws.response.JobCreateResponse
 import hr.foi.air.baufind.ws.response.JobResponse
 import hr.foi.air.baufind.ws.response.JobsForCurrentUserResponse
@@ -50,4 +52,10 @@ interface JobService {
 
     @PUT("/jobs/confirmWorker")
     suspend fun confirmWorker( @Body request: ConfirmWorkerRequest): ConfirmWorkerResponse
+
+    @GET("/jobs/getHistory")
+    suspend fun getFullJobHistory(): GetFullJobHistoryResponse
+
+    @GET("/jobs/history/{id}")
+    suspend fun getJobHistory(): GetJobHistoryResponse
 }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/network/JobService.kt
@@ -57,5 +57,5 @@ interface JobService {
     suspend fun getFullJobHistory(): GetFullJobHistoryResponse
 
     @GET("/jobs/history/{id}")
-    suspend fun getJobHistory(): GetJobHistoryResponse
+    suspend fun getJobHistory(@Path("id") id: Int): GetJobHistoryResponse
 }

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/GetFullJobHistoryResponse.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/GetFullJobHistoryResponse.kt
@@ -1,0 +1,8 @@
+package hr.foi.air.baufind.ws.response
+
+import hr.foi.air.baufind.ws.model.AllJobsHistoryModel
+
+data class GetFullJobHistoryResponse(
+    val jobs: List<AllJobsHistoryModel>,
+    val error: String?
+)

--- a/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/GetJobHistoryResponse.kt
+++ b/Software/Frontend/ws/src/main/java/hr/foi/air/baufind/ws/response/GetJobHistoryResponse.kt
@@ -1,0 +1,8 @@
+package hr.foi.air.baufind.ws.response
+
+import hr.foi.air.baufind.ws.model.JobHistoryModel
+
+data class GetJobHistoryResponse(
+    val jobHistory: JobHistoryModel,
+    val error: String?
+)


### PR DESCRIPTION
### Što je napravljeno

- Napravljena je povijest poslova
- Sa ekrana My Jobs (gdje se greškom zasad prikazuju i završeni poslovi) se pritiskom na ikonicu povijesti dolazi na ekran kompletne povijesti korisnika
![image](https://github.com/user-attachments/assets/a1d99744-2da9-493e-9927-fdc616d2f1e7)
![image](https://github.com/user-attachments/assets/7a711fae-319e-4819-8c04-3f7d3d9d1aa4)

- Na ovom ekranu je podjela na završene poslove na kojima je korisnik bio radnik i za koje je bio vlasnik
- Kada se pritisne neki posao dobiju se detalji o prošlosti tog posla
![image](https://github.com/user-attachments/assets/29ed4fef-e1fd-4c0c-8938-d3e7a286d545)
![image](https://github.com/user-attachments/assets/30f5b03d-9d51-4bfb-abb7-8cb5da6c802e)

- Na backendu imam validaciju da samo korisnik koji je ili bio vlasnik posla ili bio radnik na poslu može preko API-a zatražit ove detalje o prošlosti posla
- Iskreno to je to, ne očekujem neke buggove, možda jedino sa veličinom teksta u različitim komponentama ekrana jer su mi svi testni podatci prilično kratki stringovi ali ne bi trebao bit problem